### PR TITLE
chore: 0.9.983+4017

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3e87774a2be08ce69fe711dbf1f3f80574211529
+        commit: c8f33a1b1de5b19772970c51dbbe43f087f63f19
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.983+4017` (upstream commit `c8f33a1b1de5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25231381410](https://github.com/matthiasn/lotti/actions/runs/25231381410).
