### PR TITLE
chore: 0.9.983+4018

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c8f33a1b1de5b19772970c51dbbe43f087f63f19
+        commit: 80af7701115bf0b3f16a2285059c32efeae43dc3
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.983+4018` (upstream commit `80af7701115b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25234084115](https://github.com/matthiasn/lotti/actions/runs/25234084115).
