### PR TITLE
chore: 0.9.983+4019

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c8f33a1b1de5b19772970c51dbbe43f087f63f19
+        commit: 1ba4e22668e92c8f4082c190a89ed888cf3286d6
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.983+4019` (upstream commit `1ba4e22668e9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25235495830](https://github.com/matthiasn/lotti/actions/runs/25235495830).
