### PR TITLE
chore: 0.9.983+4021

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 80af7701115bf0b3f16a2285059c32efeae43dc3
+        commit: 2ad65dca93b4fef02b6d2a2b6273a581b642b048
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.983+4021` (upstream commit `2ad65dca93b4`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25238808875](https://github.com/matthiasn/lotti/actions/runs/25238808875).
