### PR TITLE
chore: 0.9.992+4041

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c4fb7867c3f8f82057e7ee6fa695e09326cb1d12
+        commit: d44327451f9db5d765538026121cc6ef251e2589
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.992+4041` (upstream commit `d44327451f9d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25347099988](https://github.com/matthiasn/lotti/actions/runs/25347099988).
