### PR TITLE
chore: 0.9.996+4047

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 1bfe0f19f7fd943c234cc091458c4d12b7d83a1d
+        commit: 125941bf781a044548d0134e57c6db8b476dba2e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.996+4047` (upstream commit `125941bf781a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25408245167](https://github.com/matthiasn/lotti/actions/runs/25408245167).
