### PR TITLE
chore: 0.9.997+4049

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 125941bf781a044548d0134e57c6db8b476dba2e
+        commit: 2eb8d2df7e5c9e4ec56a24c3dccabf5c3ff2d7e4
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.997+4049` (upstream commit `2eb8d2df7e5c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25463175792](https://github.com/matthiasn/lotti/actions/runs/25463175792).
