### PR TITLE
chore: 0.9.998+4052

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2eb8d2df7e5c9e4ec56a24c3dccabf5c3ff2d7e4
+        commit: d4985e5773726e9caddf91c83761ccd6ef46b638
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.998+4052` (upstream commit `d4985e577372`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25510519193](https://github.com/matthiasn/lotti/actions/runs/25510519193).
