### PR TITLE
chore: 0.9.998+4053

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2eb8d2df7e5c9e4ec56a24c3dccabf5c3ff2d7e4
+        commit: 2e3c6b585a3d04d471cd6b3468b13b94b3065727
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.998+4053` (upstream commit `2e3c6b585a3d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25517325798](https://github.com/matthiasn/lotti/actions/runs/25517325798).
