### PR TITLE
chore: 0.9.998+4054

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2eb8d2df7e5c9e4ec56a24c3dccabf5c3ff2d7e4
+        commit: 03f7aec6959c09bf7137ed7a651a473183eec387
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.998+4054` (upstream commit `03f7aec6959c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25528360037](https://github.com/matthiasn/lotti/actions/runs/25528360037).
