### PR TITLE
chore: 0.9.998+4055

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 03f7aec6959c09bf7137ed7a651a473183eec387
+        commit: f163d5ae9805ec6ca50c950de8b4210670ed7f4b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.998+4055` (upstream commit `f163d5ae9805`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25587280389](https://github.com/matthiasn/lotti/actions/runs/25587280389).
