### PR TITLE
chore: 0.9.998+4061

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 01a60eaf0d3d5cfac3dacaa76fc661b14db4964b
+        commit: c25752faab0f38e721d18c6e2673a7f5d872e6c9
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.998+4061` (upstream commit `c25752faab0f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25689494086](https://github.com/matthiasn/lotti/actions/runs/25689494086).
