### PR TITLE
chore: 0.9.999+4062

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c25752faab0f38e721d18c6e2673a7f5d872e6c9
+        commit: 05c90f6ec629504b52ef27345eee3496cf91a274
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.999+4062` (upstream commit `05c90f6ec629`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25749691208](https://github.com/matthiasn/lotti/actions/runs/25749691208).
