### PR TITLE
chore: 0.9.999+4064

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c25752faab0f38e721d18c6e2673a7f5d872e6c9
+        commit: 9b5e9f8232c1480628a1ef19b53d89245fd4090f
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.999+4064` (upstream commit `9b5e9f8232c1`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25800120287](https://github.com/matthiasn/lotti/actions/runs/25800120287).
