### PR TITLE
chore: 0.9.1000+4065

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9b5e9f8232c1480628a1ef19b53d89245fd4090f
+        commit: b73af158477ed44b2cb9e8303f047133f04e37ee
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1000+4065` (upstream commit `b73af158477e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25888916628](https://github.com/matthiasn/lotti/actions/runs/25888916628).
