### PR TITLE
chore: 0.9.1000+4066

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9b5e9f8232c1480628a1ef19b53d89245fd4090f
+        commit: 2fa06490e971dc9165d74d0a9a08e11d48a54b7b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1000+4066` (upstream commit `2fa06490e971`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25926646683](https://github.com/matthiasn/lotti/actions/runs/25926646683).
