### PR TITLE
chore: 0.9.1000+4067

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b73af158477ed44b2cb9e8303f047133f04e37ee
+        commit: ea148483a0a8f3781babce68f6ef6a762af25f76
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1000+4067` (upstream commit `ea148483a0a8`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25944345164](https://github.com/matthiasn/lotti/actions/runs/25944345164).
