### PR TITLE
chore: 0.9.1000+4069

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: ea148483a0a8f3781babce68f6ef6a762af25f76
+        commit: 43dfadfc53ac962524e074a485deb96e3f232237
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1000+4069` (upstream commit `43dfadfc53ac`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25966867388](https://github.com/matthiasn/lotti/actions/runs/25966867388).
