### PR TITLE
chore: 0.9.1001+4072

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 43dfadfc53ac962524e074a485deb96e3f232237
+        commit: 464a7432c99402069df15427a95ffec541bc9c43
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1001+4072` (upstream commit `464a7432c994`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#25995441841](https://github.com/matthiasn/lotti/actions/runs/25995441841).
