### PR TITLE
chore: 0.9.1001+4073

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 43dfadfc53ac962524e074a485deb96e3f232237
+        commit: 8b38bd3c89f306411a1925fb0a22391efeb16f9d
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1001+4073` (upstream commit `8b38bd3c89f3`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26002606922](https://github.com/matthiasn/lotti/actions/runs/26002606922).
