### PR TITLE
chore: 0.9.1002+4074

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 43dfadfc53ac962524e074a485deb96e3f232237
+        commit: 4ff0b33616246ddcffaadfda2f7ae22f499afa63
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1002+4074` (upstream commit `4ff0b3361624`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26004062563](https://github.com/matthiasn/lotti/actions/runs/26004062563).
