### PR TITLE
chore: 0.9.1002+4075

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 43dfadfc53ac962524e074a485deb96e3f232237
+        commit: 21bc94a4f2b8833e2c9633d6a987b9234b859e89
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1002+4075` (upstream commit `21bc94a4f2b8`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26005542151](https://github.com/matthiasn/lotti/actions/runs/26005542151).
