### PR TITLE
chore: 0.9.1003+4076

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 21bc94a4f2b8833e2c9633d6a987b9234b859e89
+        commit: 88ab6946787205d1618f80dd2c5685cfc05e39ed
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4076` (upstream commit `88ab69467872`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26022723329](https://github.com/matthiasn/lotti/actions/runs/26022723329).
