### PR TITLE
chore: 0.9.1003+4078

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 21bc94a4f2b8833e2c9633d6a987b9234b859e89
+        commit: bbec8e6bb2556ba1ef1c65793a37c13df5cbf438
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4078` (upstream commit `bbec8e6bb255`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26177287619](https://github.com/matthiasn/lotti/actions/runs/26177287619).
