### PR TITLE
chore: 0.9.1003+4079

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 616e5bedbc41cd876a5266e38e3005b4f97e8132
+        commit: 85def8f5247a8f622cf78ddf9a42f4c3d36e3f00
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4079` (upstream commit `85def8f5247a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26179137313](https://github.com/matthiasn/lotti/actions/runs/26179137313).
