### PR TITLE
chore: 0.9.1003+4080

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 616e5bedbc41cd876a5266e38e3005b4f97e8132
+        commit: 35bde932fa0748098441418ef58421a77bac6637
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -1890,30 +1890,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage-10.1.0.tar.gz",
-        "sha256": "8b302d17096ba88f911b7eb317c71d5e691da60a259549f42b38c658d1776d87",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage-10.2.0.tar.gz",
+        "sha256": "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage-10.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage-10.2.0"
     },
     {
         "type": "inline",
-        "contents": "8b302d17096ba88f911b7eb317c71d5e691da60a259549f42b38c658d1776d87",
+        "contents": "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage-10.1.0.sha256"
+        "dest-filename": "flutter_secure_storage-10.2.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage_darwin-0.3.0.tar.gz",
-        "sha256": "3af15a3cb2bf5b8b776832bd01776f8018766aece55623176e28b406481fb320",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage_darwin-0.3.1.tar.gz",
+        "sha256": "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_darwin-0.3.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_darwin-0.3.1"
     },
     {
         "type": "inline",
-        "contents": "3af15a3cb2bf5b8b776832bd01776f8018766aece55623176e28b406481fb320",
+        "contents": "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage_darwin-0.3.0.sha256"
+        "dest-filename": "flutter_secure_storage_darwin-0.3.1.sha256"
     },
     {
         "type": "archive",
@@ -3066,16 +3066,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matrix-7.1.0.tar.gz",
-        "sha256": "629a0e5cae675c141c6ed14a21850e74327bf0e2c90f60e225d5363cc93a50f7",
+        "url": "https://pub.dev/api/archives/matrix-7.1.2.tar.gz",
+        "sha256": "734eae63fa4b707999ee9165e0fc7e1205d1fcb37fef9727bb4f79cda460e1ab",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matrix-7.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/matrix-7.1.2"
     },
     {
         "type": "inline",
-        "contents": "629a0e5cae675c141c6ed14a21850e74327bf0e2c90f60e225d5363cc93a50f7",
+        "contents": "734eae63fa4b707999ee9165e0fc7e1205d1fcb37fef9727bb4f79cda460e1ab",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matrix-7.1.0.sha256"
+        "dest-filename": "matrix-7.1.2.sha256"
     },
     {
         "type": "archive",
@@ -3346,44 +3346,44 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/objectbox-5.3.1.tar.gz",
-        "sha256": "83d58e0ab5c4180a2f67086c449a4f2d1475932b31819271923dfc82a76f73c6",
+        "url": "https://pub.dev/api/archives/objectbox-5.3.2.tar.gz",
+        "sha256": "f68d74bfdfa6758cebf4cd319db1f4a4386c79ba8896d19e2e999faf041bac78",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/objectbox-5.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/objectbox-5.3.2"
     },
     {
         "type": "inline",
-        "contents": "83d58e0ab5c4180a2f67086c449a4f2d1475932b31819271923dfc82a76f73c6",
+        "contents": "f68d74bfdfa6758cebf4cd319db1f4a4386c79ba8896d19e2e999faf041bac78",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "objectbox-5.3.1.sha256"
+        "dest-filename": "objectbox-5.3.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/objectbox_flutter_libs-5.3.1.tar.gz",
-        "sha256": "fd4e8ed03e2b2bfeb8aa965435d7c5523ec7e962f1ffecf6e7da6c1f4d170419",
+        "url": "https://pub.dev/api/archives/objectbox_flutter_libs-5.3.2.tar.gz",
+        "sha256": "604d26fac4548693449c9ea802e007d4adf7f31e361ae3ebf362ac142295078d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/objectbox_flutter_libs-5.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/objectbox_flutter_libs-5.3.2"
     },
     {
         "type": "inline",
-        "contents": "fd4e8ed03e2b2bfeb8aa965435d7c5523ec7e962f1ffecf6e7da6c1f4d170419",
+        "contents": "604d26fac4548693449c9ea802e007d4adf7f31e361ae3ebf362ac142295078d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "objectbox_flutter_libs-5.3.1.sha256"
+        "dest-filename": "objectbox_flutter_libs-5.3.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/objectbox_generator-5.3.1.tar.gz",
-        "sha256": "daa95f21c7140c619ffc1abee2465541d4f0317b8c3bbf2141be1a9e5c507a1d",
+        "url": "https://pub.dev/api/archives/objectbox_generator-5.3.2.tar.gz",
+        "sha256": "b5f6b9e6062635689d777ba2b3a16548991eb1e61007baf607022537e3bc0436",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/objectbox_generator-5.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/objectbox_generator-5.3.2"
     },
     {
         "type": "inline",
-        "contents": "daa95f21c7140c619ffc1abee2465541d4f0317b8c3bbf2141be1a9e5c507a1d",
+        "contents": "b5f6b9e6062635689d777ba2b3a16548991eb1e61007baf607022537e3bc0436",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "objectbox_generator-5.3.1.sha256"
+        "dest-filename": "objectbox_generator-5.3.2.sha256"
     },
     {
         "type": "archive",
@@ -4829,16 +4829,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_common-2.5.7.tar.gz",
-        "sha256": "f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21",
+        "url": "https://pub.dev/api/archives/sqflite_common-2.5.8.tar.gz",
+        "sha256": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.7"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.8"
     },
     {
         "type": "inline",
-        "contents": "f8a08a13fb8f0f8c590df89d745000bed44a673ed94bac846739e1a016875c21",
+        "contents": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_common-2.5.7.sha256"
+        "dest-filename": "sqflite_common-2.5.8.sha256"
     },
     {
         "type": "archive",
@@ -5319,16 +5319,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/url_launcher_android-6.3.29.tar.gz",
-        "sha256": "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572",
+        "url": "https://pub.dev/api/archives/url_launcher_android-6.3.30.tar.gz",
+        "sha256": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/url_launcher_android-6.3.29"
+        "dest": ".pub-cache/hosted/pub.dev/url_launcher_android-6.3.30"
     },
     {
         "type": "inline",
-        "contents": "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572",
+        "contents": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "url_launcher_android-6.3.29.sha256"
+        "dest-filename": "url_launcher_android-6.3.30.sha256"
     },
     {
         "type": "archive",
@@ -5445,16 +5445,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vector_graphics-1.2.0.tar.gz",
-        "sha256": "6409a25046024f0f8c5d8a59fec314081e81f9d436b66ca4015a8b49772bf445",
+        "url": "https://pub.dev/api/archives/vector_graphics-1.2.2.tar.gz",
+        "sha256": "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vector_graphics-1.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/vector_graphics-1.2.2"
     },
     {
         "type": "inline",
-        "contents": "6409a25046024f0f8c5d8a59fec314081e81f9d436b66ca4015a8b49772bf445",
+        "contents": "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vector_graphics-1.2.0.sha256"
+        "dest-filename": "vector_graphics-1.2.2.sha256"
     },
     {
         "type": "archive",
@@ -5473,16 +5473,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vector_graphics_compiler-1.2.1.tar.gz",
-        "sha256": "06f0c50f88a1a020f95138dcc14ef4d5a039ced3f89b386209e6763dfa2cefa0",
+        "url": "https://pub.dev/api/archives/vector_graphics_compiler-1.2.3.tar.gz",
+        "sha256": "b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vector_graphics_compiler-1.2.1"
+        "dest": ".pub-cache/hosted/pub.dev/vector_graphics_compiler-1.2.3"
     },
     {
         "type": "inline",
-        "contents": "06f0c50f88a1a020f95138dcc14ef4d5a039ced3f89b386209e6763dfa2cefa0",
+        "contents": "b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vector_graphics_compiler-1.2.1.sha256"
+        "dest-filename": "vector_graphics_compiler-1.2.3.sha256"
     },
     {
         "type": "archive",
@@ -5543,16 +5543,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/video_player_avfoundation-2.9.6.tar.gz",
-        "sha256": "a39d6f28f8069564d8cc17396472f958dd9eaddf2d5c8e90aad4d793ac369bf3",
+        "url": "https://pub.dev/api/archives/video_player_avfoundation-2.9.7.tar.gz",
+        "sha256": "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/video_player_avfoundation-2.9.6"
+        "dest": ".pub-cache/hosted/pub.dev/video_player_avfoundation-2.9.7"
     },
     {
         "type": "inline",
-        "contents": "a39d6f28f8069564d8cc17396472f958dd9eaddf2d5c8e90aad4d793ac369bf3",
+        "contents": "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "video_player_avfoundation-2.9.6.sha256"
+        "dest-filename": "video_player_avfoundation-2.9.7.sha256"
     },
     {
         "type": "archive",
@@ -7294,6 +7294,6 @@
     {
         "type": "patch",
         "path": "generated/patches/objectbox_flutter_libs/5.3.1-CMakeLists.txt.patch",
-        "dest": ".pub-cache/hosted/pub.dev/objectbox_flutter_libs-5.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/objectbox_flutter_libs-5.3.2"
     }
 ]


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4080` (upstream commit `35bde932fa07`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26180017373](https://github.com/matthiasn/lotti/actions/runs/26180017373).
