### PR TITLE
chore: 0.9.1003+4083

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b201d603308be9e920b97238fa3c327998faedb6
+        commit: 21dcbbb5f400fdd6c727ddab6585b8f25feb7e02
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4083` (upstream commit `21dcbbb5f400`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26195802013](https://github.com/matthiasn/lotti/actions/runs/26195802013).
