### PR TITLE
chore: 0.9.1003+4084

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b201d603308be9e920b97238fa3c327998faedb6
+        commit: 49d78fc0ebb3bf0252dc78ca057b620ab679b9f2
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4084` (upstream commit `49d78fc0ebb3`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26196441544](https://github.com/matthiasn/lotti/actions/runs/26196441544).
