### PR TITLE
chore: 0.9.1003+4085

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b201d603308be9e920b97238fa3c327998faedb6
+        commit: 1c80bdcda3963acc06b6e4ddb00548fb39de53ca
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1003+4085` (upstream commit `1c80bdcda396`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26237940298](https://github.com/matthiasn/lotti/actions/runs/26237940298).
