### PR TITLE
chore: 0.9.1004+4086

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 1c80bdcda3963acc06b6e4ddb00548fb39de53ca
+        commit: 259826739196e1db92e6245a79d5fc7b386ceb26
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1004+4086` (upstream commit `259826739196`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26255589196](https://github.com/matthiasn/lotti/actions/runs/26255589196).
