### PR TITLE
chore: 0.9.1007+4090

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: fb35b1f9efb33a9ca16e4bfb5392f8f01cdae116
+        commit: 5880a32d8a47eba0d7b32c6d3c10d697f72f7f82
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -1904,44 +1904,44 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage-10.2.0.tar.gz",
-        "sha256": "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage-10.3.0.tar.gz",
+        "sha256": "d2a6ac2df7353f5ca47eb159a5407c1dba7ec48ca0e02dc38c9ff4d29447b261",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage-10.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage-10.3.0"
     },
     {
         "type": "inline",
-        "contents": "6848263f9744072d0977347c383fb8b57d9780319a6bf5238b5a2866a029de62",
+        "contents": "d2a6ac2df7353f5ca47eb159a5407c1dba7ec48ca0e02dc38c9ff4d29447b261",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage-10.2.0.sha256"
+        "dest-filename": "flutter_secure_storage-10.3.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage_darwin-0.3.1.tar.gz",
-        "sha256": "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage_darwin-0.3.2.tar.gz",
+        "sha256": "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_darwin-0.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_darwin-0.3.2"
     },
     {
         "type": "inline",
-        "contents": "67cd1ff671add31dc13e45194398187a04bb63804b37fa47866afae296d73fcb",
+        "contents": "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage_darwin-0.3.1.sha256"
+        "dest-filename": "flutter_secure_storage_darwin-0.3.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage_linux-3.0.0.tar.gz",
-        "sha256": "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage_linux-3.0.1.tar.gz",
+        "sha256": "a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_linux-3.0.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_linux-3.0.1"
     },
     {
         "type": "inline",
-        "contents": "2b5c76dce569ab752d55a1cee6a2242bcc11fdba927078fb88c503f150767cda",
+        "contents": "a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage_linux-3.0.0.sha256"
+        "dest-filename": "flutter_secure_storage_linux-3.0.1.sha256"
     },
     {
         "type": "archive",
@@ -4116,86 +4116,86 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record-6.2.0.tar.gz",
-        "sha256": "d5b6b334f3ab02460db6544e08583c942dbf23e3504bf1e14fd4cbe3d9409277",
+        "url": "https://pub.dev/api/archives/record-6.2.1.tar.gz",
+        "sha256": "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record-6.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/record-6.2.1"
     },
     {
         "type": "inline",
-        "contents": "d5b6b334f3ab02460db6544e08583c942dbf23e3504bf1e14fd4cbe3d9409277",
+        "contents": "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record-6.2.0.sha256"
+        "dest-filename": "record-6.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_android-1.5.1.tar.gz",
-        "sha256": "94783f08403aed33ffb68797bf0715b0812eb852f3c7985644c945faea462ba1",
+        "url": "https://pub.dev/api/archives/record_android-1.5.2.tar.gz",
+        "sha256": "eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_android-1.5.1"
+        "dest": ".pub-cache/hosted/pub.dev/record_android-1.5.2"
     },
     {
         "type": "inline",
-        "contents": "94783f08403aed33ffb68797bf0715b0812eb852f3c7985644c945faea462ba1",
+        "contents": "eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_android-1.5.1.sha256"
+        "dest-filename": "record_android-1.5.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_ios-1.2.0.tar.gz",
-        "sha256": "8df7c136131bd05efc19256af29b2ba6ccc000ccc2c80d4b6b6d7a8d21a3b5a9",
+        "url": "https://pub.dev/api/archives/record_ios-1.2.1.tar.gz",
+        "sha256": "c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_ios-1.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/record_ios-1.2.1"
     },
     {
         "type": "inline",
-        "contents": "8df7c136131bd05efc19256af29b2ba6ccc000ccc2c80d4b6b6d7a8d21a3b5a9",
+        "contents": "c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_ios-1.2.0.sha256"
+        "dest-filename": "record_ios-1.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_linux-1.3.0.tar.gz",
-        "sha256": "c31a35cc158cd666fc6395f7f56fc054f31685571684be6b97670a27649ce5c7",
+        "url": "https://pub.dev/api/archives/record_linux-1.3.1.tar.gz",
+        "sha256": "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_linux-1.3.0"
+        "dest": ".pub-cache/hosted/pub.dev/record_linux-1.3.1"
     },
     {
         "type": "inline",
-        "contents": "c31a35cc158cd666fc6395f7f56fc054f31685571684be6b97670a27649ce5c7",
+        "contents": "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_linux-1.3.0.sha256"
+        "dest-filename": "record_linux-1.3.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_macos-1.2.1.tar.gz",
-        "sha256": "084902e63fc9c0c224c29203d6c75f0bdf9b6a40536c9d916393c8f4c4256488",
+        "url": "https://pub.dev/api/archives/record_macos-1.2.2.tar.gz",
+        "sha256": "cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_macos-1.2.1"
+        "dest": ".pub-cache/hosted/pub.dev/record_macos-1.2.2"
     },
     {
         "type": "inline",
-        "contents": "084902e63fc9c0c224c29203d6c75f0bdf9b6a40536c9d916393c8f4c4256488",
+        "contents": "cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_macos-1.2.1.sha256"
+        "dest-filename": "record_macos-1.2.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_platform_interface-1.5.0.tar.gz",
-        "sha256": "8a81dbc4e14e1272a285bbfef6c9136d070a47d9b0d1f40aa6193516253ee2f6",
+        "url": "https://pub.dev/api/archives/record_platform_interface-1.6.0.tar.gz",
+        "sha256": "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_platform_interface-1.5.0"
+        "dest": ".pub-cache/hosted/pub.dev/record_platform_interface-1.6.0"
     },
     {
         "type": "inline",
-        "contents": "8a81dbc4e14e1272a285bbfef6c9136d070a47d9b0d1f40aa6193516253ee2f6",
+        "contents": "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_platform_interface-1.5.0.sha256"
+        "dest-filename": "record_platform_interface-1.6.0.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1007+4090` (upstream commit `5880a32d8a47`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26317977628](https://github.com/matthiasn/lotti/actions/runs/26317977628).
