### PR TITLE
chore: 0.9.1007+4091

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5880a32d8a47eba0d7b32c6d3c10d697f72f7f82
+        commit: 2391b3e1838e53d73857ee85568fbac3142c0d2a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1007+4091` (upstream commit `2391b3e1838e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26371381531](https://github.com/matthiasn/lotti/actions/runs/26371381531).
