### PR TITLE
chore: 0.9.1008+4092

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5880a32d8a47eba0d7b32c6d3c10d697f72f7f82
+        commit: 5e19a99517480d020c5afd8f833a2713c86eb766
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1008+4092` (upstream commit `5e19a9951748`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26371787274](https://github.com/matthiasn/lotti/actions/runs/26371787274).
