### PR TITLE
chore: 0.9.1008+4093

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5e19a99517480d020c5afd8f833a2713c86eb766
+        commit: a87aca2f1857e8a6ab552fcd98b2a3926da195f6
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1008+4093` (upstream commit `a87aca2f1857`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26465464722](https://github.com/matthiasn/lotti/actions/runs/26465464722).
