### PR TITLE
chore: 0.9.1009+4094

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5e19a99517480d020c5afd8f833a2713c86eb766
+        commit: c1ab36a34f66b9c44213e334a8f93091c338c4ec
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1009+4094` (upstream commit `c1ab36a34f66`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26479079640](https://github.com/matthiasn/lotti/actions/runs/26479079640).
