### PR TITLE
chore: 0.9.1009+4096

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c1ab36a34f66b9c44213e334a8f93091c338c4ec
+        commit: 64bff0fdd6dca419ad8ff561b057afd26f510d85
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1009+4096` (upstream commit `64bff0fdd6dc`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26546095497](https://github.com/matthiasn/lotti/actions/runs/26546095497).
