### PR TITLE
chore: 0.9.1010+4097

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c1ab36a34f66b9c44213e334a8f93091c338c4ec
+        commit: d25616512d8260856152a52c058f0557c889438e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4097` (upstream commit `d25616512d82`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26547702429](https://github.com/matthiasn/lotti/actions/runs/26547702429).
