### PR TITLE
chore: 0.9.1010+4098

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 64bff0fdd6dca419ad8ff561b057afd26f510d85
+        commit: e5bcf084b8403ab5cb45161a5c01e33059064829
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4098` (upstream commit `e5bcf084b840`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26559277476](https://github.com/matthiasn/lotti/actions/runs/26559277476).
