### PR TITLE
chore: 0.9.1010+4100

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e5bcf084b8403ab5cb45161a5c01e33059064829
+        commit: 6fa36e62b219b6e6a8c3d93fb6ef183975143b58
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4100` (upstream commit `6fa36e62b219`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26568717102](https://github.com/matthiasn/lotti/actions/runs/26568717102).
