### PR TITLE
chore: 0.9.1010+4102

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f8cd1b17362a40ec081f556e0b56b02f12ac4130
+        commit: c2eb9866cb932f0e144d6748256d20e018c8ee2c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4102` (upstream commit `c2eb9866cb93`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26660254805](https://github.com/matthiasn/lotti/actions/runs/26660254805).
