### PR TITLE
chore: 0.9.1010+4103

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f8cd1b17362a40ec081f556e0b56b02f12ac4130
+        commit: 91cf877b9f0ec667661f20719ca768fa6db62627
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4103` (upstream commit `91cf877b9f0e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26662757474](https://github.com/matthiasn/lotti/actions/runs/26662757474).
