### PR TITLE
chore: 0.9.1010+4104

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f8cd1b17362a40ec081f556e0b56b02f12ac4130
+        commit: 78017df2784ac037ba85b5bedcb4e5c71411b7af
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1010+4104` (upstream commit `78017df2784a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26669327526](https://github.com/matthiasn/lotti/actions/runs/26669327526).
