### PR TITLE
chore: 0.9.1011+4107

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c17579d58db433d694d2509cb8f855a60dc5b637
+        commit: 46731f85f29dea72613c74d77d66e98e44f7341a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1011+4107` (upstream commit `46731f85f29d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26685109719](https://github.com/matthiasn/lotti/actions/runs/26685109719).
