### PR TITLE
chore: 0.9.1012+4109

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 46731f85f29dea72613c74d77d66e98e44f7341a
+        commit: 7f1c5a24dc3d01dd5e08c8aa2f615be53abe66fd
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1012+4109` (upstream commit `7f1c5a24dc3d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26726158731](https://github.com/matthiasn/lotti/actions/runs/26726158731).
