### PR TITLE
chore: 0.9.1012+4110

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 46731f85f29dea72613c74d77d66e98e44f7341a
+        commit: a4288766e222d3c425f3880560d1c600c099982b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1012+4110` (upstream commit `a4288766e222`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26729692767](https://github.com/matthiasn/lotti/actions/runs/26729692767).
