### PR TITLE
chore: 0.9.1013+4111

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: a4288766e222d3c425f3880560d1c600c099982b
+        commit: e2a14f8dc56e67eb3d61e7f8783d8802eb97d2a0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1013+4111` (upstream commit `e2a14f8dc56e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26778495148](https://github.com/matthiasn/lotti/actions/runs/26778495148).
