### PR TITLE
chore: 0.9.1013+4112

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e2a14f8dc56e67eb3d61e7f8783d8802eb97d2a0
+        commit: 2e314b475f7bbf00930237c92bdcd8f9ad3aa31b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1013+4112` (upstream commit `2e314b475f7b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26837063871](https://github.com/matthiasn/lotti/actions/runs/26837063871).
