### PR TITLE
chore: 0.9.1015+4115

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 492620dc7a0278f83811b01f37b4198d7eefa408
+        commit: 2b16d6a112d561c39cfef974cc7fbaf8ac04393a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1015+4115` (upstream commit `2b16d6a112d5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#26979090243](https://github.com/matthiasn/lotti/actions/runs/26979090243).
