### PR TITLE
chore: 0.9.1015+4117

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 492620dc7a0278f83811b01f37b4198d7eefa408
+        commit: 98253c83eb29e3ef32dc19ca1cbc98d71926bd51
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -170,16 +170,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/audioplayers-6.7.0.tar.gz",
-        "sha256": "1d0c1b1f2095e59080e2d5046639096417a86687d89778da41b0c9a06d683dfd",
+        "url": "https://pub.dev/api/archives/audioplayers-6.7.1.tar.gz",
+        "sha256": "f16640453cc47487b7de72a2b28d37c7df1ac97999849f4a46d92b1d2b0f093d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/audioplayers-6.7.0"
+        "dest": ".pub-cache/hosted/pub.dev/audioplayers-6.7.1"
     },
     {
         "type": "inline",
-        "contents": "1d0c1b1f2095e59080e2d5046639096417a86687d89778da41b0c9a06d683dfd",
+        "contents": "f16640453cc47487b7de72a2b28d37c7df1ac97999849f4a46d92b1d2b0f093d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "audioplayers-6.7.0.sha256"
+        "dest-filename": "audioplayers-6.7.1.sha256"
     },
     {
         "type": "archive",
@@ -926,16 +926,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/dbus-0.7.12.tar.gz",
-        "sha256": "d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270",
+        "url": "https://pub.dev/api/archives/dbus-0.7.14.tar.gz",
+        "sha256": "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/dbus-0.7.12"
+        "dest": ".pub-cache/hosted/pub.dev/dbus-0.7.14"
     },
     {
         "type": "inline",
-        "contents": "d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270",
+        "contents": "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "dbus-0.7.12.sha256"
+        "dest-filename": "dbus-0.7.14.sha256"
     },
     {
         "type": "archive",
@@ -1806,16 +1806,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_plugin_android_lifecycle-2.0.34.tar.gz",
-        "sha256": "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0",
+        "url": "https://pub.dev/api/archives/flutter_plugin_android_lifecycle-2.0.35.tar.gz",
+        "sha256": "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_plugin_android_lifecycle-2.0.34"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_plugin_android_lifecycle-2.0.35"
     },
     {
         "type": "inline",
-        "contents": "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0",
+        "contents": "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_plugin_android_lifecycle-2.0.34.sha256"
+        "dest-filename": "flutter_plugin_android_lifecycle-2.0.35.sha256"
     },
     {
         "type": "archive",
@@ -2142,16 +2142,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/genui-0.9.0.tar.gz",
-        "sha256": "be0d9d689e15991c43ef6f1f6aa45a3bdea1ffe2a2259ac0ab38881cf8f346dd",
+        "url": "https://pub.dev/api/archives/genui-0.9.2.tar.gz",
+        "sha256": "3e6688a9bc5e0147be3c3837f9bfc4588618416dd5a346b746aa9f64f8ffd7bf",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/genui-0.9.0"
+        "dest": ".pub-cache/hosted/pub.dev/genui-0.9.2"
     },
     {
         "type": "inline",
-        "contents": "be0d9d689e15991c43ef6f1f6aa45a3bdea1ffe2a2259ac0ab38881cf8f346dd",
+        "contents": "3e6688a9bc5e0147be3c3837f9bfc4588618416dd5a346b746aa9f64f8ffd7bf",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "genui-0.9.0.sha256"
+        "dest-filename": "genui-0.9.2.sha256"
     },
     {
         "type": "archive",
@@ -2478,16 +2478,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/image_picker_android-0.8.13+17.tar.gz",
-        "sha256": "d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f",
+        "url": "https://pub.dev/api/archives/image_picker_android-0.8.13+19.tar.gz",
+        "sha256": "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/image_picker_android-0.8.13+17"
+        "dest": ".pub-cache/hosted/pub.dev/image_picker_android-0.8.13+19"
     },
     {
         "type": "inline",
-        "contents": "d5b3e1774af29c9ab00103afb0d4614070f924d2e0057ac867ec98800114793f",
+        "contents": "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "image_picker_android-0.8.13+17.sha256"
+        "dest-filename": "image_picker_android-0.8.13+19.sha256"
     },
     {
         "type": "archive",
@@ -2814,16 +2814,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/json_schema_builder-0.1.3.tar.gz",
-        "sha256": "65035d48d028401ad0ffc8c2f173209c7b1441e465a942a0f909070fae33170c",
+        "url": "https://pub.dev/api/archives/json_schema_builder-0.1.5.tar.gz",
+        "sha256": "9c45a80bc25d3b091e96a5a5da49dc7f80d5b0c8496cff60409f9739331ccefb",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/json_schema_builder-0.1.3"
+        "dest": ".pub-cache/hosted/pub.dev/json_schema_builder-0.1.5"
     },
     {
         "type": "inline",
-        "contents": "65035d48d028401ad0ffc8c2f173209c7b1441e465a942a0f909070fae33170c",
+        "contents": "9c45a80bc25d3b091e96a5a5da49dc7f80d5b0c8496cff60409f9739331ccefb",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "json_schema_builder-0.1.3.sha256"
+        "dest-filename": "json_schema_builder-0.1.5.sha256"
     },
     {
         "type": "archive",
@@ -3584,16 +3584,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler-12.0.2.tar.gz",
-        "sha256": "ca045d03615023c08ccdb297aad46a9198193666039ddd36d4d85fd0b1864b98",
+        "url": "https://pub.dev/api/archives/permission_handler-12.0.3.tar.gz",
+        "sha256": "fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler-12.0.2"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler-12.0.3"
     },
     {
         "type": "inline",
-        "contents": "ca045d03615023c08ccdb297aad46a9198193666039ddd36d4d85fd0b1864b98",
+        "contents": "fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler-12.0.2.sha256"
+        "dest-filename": "permission_handler-12.0.3.sha256"
     },
     {
         "type": "archive",
@@ -3612,16 +3612,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_apple-9.4.8.tar.gz",
-        "sha256": "447c18bc3c5fdea5c3039f042b2b365fd51e3634f5f6e269ed22c1f00071addc",
+        "url": "https://pub.dev/api/archives/permission_handler_apple-9.4.9.tar.gz",
+        "sha256": "e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.4.8"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.4.9"
     },
     {
         "type": "inline",
-        "contents": "447c18bc3c5fdea5c3039f042b2b365fd51e3634f5f6e269ed22c1f00071addc",
+        "contents": "e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_apple-9.4.8.sha256"
+        "dest-filename": "permission_handler_apple-9.4.9.sha256"
     },
     {
         "type": "archive",
@@ -4507,16 +4507,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/shared_preferences_android-2.4.23.tar.gz",
-        "sha256": "e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53",
+        "url": "https://pub.dev/api/archives/shared_preferences_android-2.4.25.tar.gz",
+        "sha256": "a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/shared_preferences_android-2.4.23"
+        "dest": ".pub-cache/hosted/pub.dev/shared_preferences_android-2.4.25"
     },
     {
         "type": "inline",
-        "contents": "e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53",
+        "contents": "a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "shared_preferences_android-2.4.23.sha256"
+        "dest-filename": "shared_preferences_android-2.4.25.sha256"
     },
     {
         "type": "archive",
@@ -4801,44 +4801,44 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite-2.4.2+1.tar.gz",
-        "sha256": "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a",
+        "url": "https://pub.dev/api/archives/sqflite-2.4.3.tar.gz",
+        "sha256": "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite-2.4.2+1"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite-2.4.3"
     },
     {
         "type": "inline",
-        "contents": "564cfed0746fe53140c23b70b308e045c3b31f17778f2f326ccb7d804ea0250a",
+        "contents": "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite-2.4.2+1.sha256"
+        "dest-filename": "sqflite-2.4.3.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_android-2.4.2+3.tar.gz",
-        "sha256": "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40",
+        "url": "https://pub.dev/api/archives/sqflite_android-2.4.3.tar.gz",
+        "sha256": "d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_android-2.4.2+3"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_android-2.4.3"
     },
     {
         "type": "inline",
-        "contents": "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40",
+        "contents": "d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_android-2.4.2+3.sha256"
+        "dest-filename": "sqflite_android-2.4.3.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_common-2.5.8.tar.gz",
-        "sha256": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
+        "url": "https://pub.dev/api/archives/sqflite_common-2.5.9.tar.gz",
+        "sha256": "cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.8"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.9"
     },
     {
         "type": "inline",
-        "contents": "1581ffbf7a0e333b380d6a30737d78516b826cb35beb7fb0bf8a3ea0c678b465",
+        "contents": "cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_common-2.5.8.sha256"
+        "dest-filename": "sqflite_common-2.5.9.sha256"
     },
     {
         "type": "archive",
@@ -4857,30 +4857,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_darwin-2.4.2.tar.gz",
-        "sha256": "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3",
+        "url": "https://pub.dev/api/archives/sqflite_darwin-2.4.3.tar.gz",
+        "sha256": "164a5d73ab87a134566057219988bafde837029a64264e61f1f04376ef3cfcd2",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_darwin-2.4.2"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_darwin-2.4.3"
     },
     {
         "type": "inline",
-        "contents": "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3",
+        "contents": "164a5d73ab87a134566057219988bafde837029a64264e61f1f04376ef3cfcd2",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_darwin-2.4.2.sha256"
+        "dest-filename": "sqflite_darwin-2.4.3.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_platform_interface-2.4.0.tar.gz",
-        "sha256": "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920",
+        "url": "https://pub.dev/api/archives/sqflite_platform_interface-2.4.1.tar.gz",
+        "sha256": "f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_platform_interface-2.4.0"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_platform_interface-2.4.1"
     },
     {
         "type": "inline",
-        "contents": "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920",
+        "contents": "f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_platform_interface-2.4.0.sha256"
+        "dest-filename": "sqflite_platform_interface-2.4.1.sha256"
     },
     {
         "type": "archive",
@@ -5081,16 +5081,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/synchronized-3.4.0+1.tar.gz",
-        "sha256": "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5",
+        "url": "https://pub.dev/api/archives/synchronized-3.4.1.tar.gz",
+        "sha256": "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/synchronized-3.4.0+1"
+        "dest": ".pub-cache/hosted/pub.dev/synchronized-3.4.1"
     },
     {
         "type": "inline",
-        "contents": "63896c27e81b28f8cb4e69ead0d3e8f03f1d1e5fc531a3e579cabed6a2c7c9e5",
+        "contents": "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "synchronized-3.4.0+1.sha256"
+        "dest-filename": "synchronized-3.4.1.sha256"
     },
     {
         "type": "archive",
@@ -5319,16 +5319,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/url_launcher_android-6.3.30.tar.gz",
-        "sha256": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
+        "url": "https://pub.dev/api/archives/url_launcher_android-6.3.32.tar.gz",
+        "sha256": "b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/url_launcher_android-6.3.30"
+        "dest": ".pub-cache/hosted/pub.dev/url_launcher_android-6.3.32"
     },
     {
         "type": "inline",
-        "contents": "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c",
+        "contents": "b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "url_launcher_android-6.3.30.sha256"
+        "dest-filename": "url_launcher_android-6.3.32.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1015+4117` (upstream commit `98253c83eb29`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27056855282](https://github.com/matthiasn/lotti/actions/runs/27056855282).
