### PR TITLE
chore: 0.9.1016+4119

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 98253c83eb29e3ef32dc19ca1cbc98d71926bd51
+        commit: f56e0f28216218fe53f2ad7590857b3659529f79
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1016+4119` (upstream commit `f56e0f282162`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27060165387](https://github.com/matthiasn/lotti/actions/runs/27060165387).
