### PR TITLE
chore: 0.9.1016+4120

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f56e0f28216218fe53f2ad7590857b3659529f79
+        commit: 3ba81029d538e5a2416e4f65af924ff35d66c557
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1016+4120` (upstream commit `3ba81029d538`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27062525753](https://github.com/matthiasn/lotti/actions/runs/27062525753).
