### PR TITLE
chore: 0.9.1016+4121

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3ba81029d538e5a2416e4f65af924ff35d66c557
+        commit: 3ddbf4621ac02a3cade4da355f14488381c890af
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1016+4121` (upstream commit `3ddbf4621ac0`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27075994295](https://github.com/matthiasn/lotti/actions/runs/27075994295).
