### PR TITLE
chore: 0.9.1016+4122

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3ddbf4621ac02a3cade4da355f14488381c890af
+        commit: 9843e3acaee5a5ccb72d9c6e7b7eb602997b32fe
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1016+4122` (upstream commit `9843e3acaee5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27096042195](https://github.com/matthiasn/lotti/actions/runs/27096042195).
