### PR TITLE
chore: 0.9.1017+4124

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9843e3acaee5a5ccb72d9c6e7b7eb602997b32fe
+        commit: 1bc9251e7e0f33f831bcbe0ce941a7f0d21616a0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1017+4124` (upstream commit `1bc9251e7e0f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27105602759](https://github.com/matthiasn/lotti/actions/runs/27105602759).
