### PR TITLE
chore: 0.9.1017+4125

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9843e3acaee5a5ccb72d9c6e7b7eb602997b32fe
+        commit: 6c2c33ebb11edd557ddcd07216de474dcc631972
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1017+4125` (upstream commit `6c2c33ebb11e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27141456252](https://github.com/matthiasn/lotti/actions/runs/27141456252).
