### PR TITLE
chore: 0.9.1017+4126

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 6c2c33ebb11edd557ddcd07216de474dcc631972
+        commit: f6e6f848b644d5f08ff9fde1af057e7e27ccfb2e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1017+4126` (upstream commit `f6e6f848b644`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27173206921](https://github.com/matthiasn/lotti/actions/runs/27173206921).
