### PR TITLE
chore: 0.9.1018+4127

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 6c2c33ebb11edd557ddcd07216de474dcc631972
+        commit: 5141148115fea7b3c72010e7367652e10acaab19
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1018+4127` (upstream commit `5141148115fe`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27173782763](https://github.com/matthiasn/lotti/actions/runs/27173782763).
