### PR TITLE
chore: 0.9.1018+4128

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f6e6f848b644d5f08ff9fde1af057e7e27ccfb2e
+        commit: b403ba374ba15f9eba3ba6b0ee949acf452cb807
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1018+4128` (upstream commit `b403ba374ba1`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27235221201](https://github.com/matthiasn/lotti/actions/runs/27235221201).
