### PR TITLE
chore: 0.9.1018+4129

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b403ba374ba15f9eba3ba6b0ee949acf452cb807
+        commit: d43f900dff3036a5cdab687888d449a99433eb43
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1018+4129` (upstream commit `d43f900dff30`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27240132734](https://github.com/matthiasn/lotti/actions/runs/27240132734).
