### PR TITLE
chore: 0.9.1018+4130

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b403ba374ba15f9eba3ba6b0ee949acf452cb807
+        commit: 81f80f1ec230478a3f1164ca04b2060515910f8b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1018+4130` (upstream commit `81f80f1ec230`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27313805283](https://github.com/matthiasn/lotti/actions/runs/27313805283).
