### PR TITLE
chore: 0.9.1018+4131

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 81f80f1ec230478a3f1164ca04b2060515910f8b
+        commit: 62c2f4129a0ba49c0abdd65522b38482059d6e56
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1018+4131` (upstream commit `62c2f4129a0b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27315449675](https://github.com/matthiasn/lotti/actions/runs/27315449675).
