### PR TITLE
chore: 0.9.1019+4132

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 81f80f1ec230478a3f1164ca04b2060515910f8b
+        commit: b708d4da6a81c395bda256f565d55957e42acf87
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1019+4132` (upstream commit `b708d4da6a81`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27348807478](https://github.com/matthiasn/lotti/actions/runs/27348807478).
