### PR TITLE
chore: 0.9.1022+4138

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 81f80f1ec230478a3f1164ca04b2060515910f8b
+        commit: 9f6b2ca256850f528f089396818fa4e28c2e65ce
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -730,16 +730,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/coverage-1.15.0.tar.gz",
-        "sha256": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "url": "https://pub.dev/api/archives/coverage-1.15.1.tar.gz",
+        "sha256": "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/coverage-1.15.0"
+        "dest": ".pub-cache/hosted/pub.dev/coverage-1.15.1"
     },
     {
         "type": "inline",
-        "contents": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "contents": "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "coverage-1.15.0.sha256"
+        "dest-filename": "coverage-1.15.1.sha256"
     },
     {
         "type": "archive",
@@ -3066,16 +3066,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matrix-7.2.2.tar.gz",
-        "sha256": "d170e4dc31d0d99e8a181388ff1d06c48f9b9163586a3867f23041fb220a79d3",
+        "url": "https://pub.dev/api/archives/matrix-7.2.3.tar.gz",
+        "sha256": "e52477dcc118fe89b7f40123c2dc9fe681fee0529738007c8ba82ccaf9fb6993",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matrix-7.2.2"
+        "dest": ".pub-cache/hosted/pub.dev/matrix-7.2.3"
     },
     {
         "type": "inline",
-        "contents": "d170e4dc31d0d99e8a181388ff1d06c48f9b9163586a3867f23041fb220a79d3",
+        "contents": "e52477dcc118fe89b7f40123c2dc9fe681fee0529738007c8ba82ccaf9fb6993",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matrix-7.2.2.sha256"
+        "dest-filename": "matrix-7.2.3.sha256"
     },
     {
         "type": "archive",
@@ -3262,16 +3262,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/msix-3.16.13.tar.gz",
-        "sha256": "b6b08e7a7b5d1845f2b1d31216d5b1fb558e98251efefe54eb79ed00d27bc2ac",
+        "url": "https://pub.dev/api/archives/msix-3.17.0.tar.gz",
+        "sha256": "bed33b53662c7eac66dc4f9b4176d03140307e6a892ab21ce529be6f74393db0",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/msix-3.16.13"
+        "dest": ".pub-cache/hosted/pub.dev/msix-3.17.0"
     },
     {
         "type": "inline",
-        "contents": "b6b08e7a7b5d1845f2b1d31216d5b1fb558e98251efefe54eb79ed00d27bc2ac",
+        "contents": "bed33b53662c7eac66dc4f9b4176d03140307e6a892ab21ce529be6f74393db0",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "msix-3.16.13.sha256"
+        "dest-filename": "msix-3.17.0.sha256"
     },
     {
         "type": "archive",
@@ -3612,16 +3612,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_apple-9.4.9.tar.gz",
-        "sha256": "e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d",
+        "url": "https://pub.dev/api/archives/permission_handler_apple-9.4.10.tar.gz",
+        "sha256": "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.4.9"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.4.10"
     },
     {
         "type": "inline",
-        "contents": "e20daf680eef1ca62ffe8c8c526b778cc386d50137c77ac71c8ec9c88c13fb9d",
+        "contents": "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_apple-9.4.9.sha256"
+        "dest-filename": "permission_handler_apple-9.4.10.sha256"
     },
     {
         "type": "archive",
@@ -4367,72 +4367,72 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/screen_retriever-0.2.0.tar.gz",
-        "sha256": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "url": "https://pub.dev/api/archives/screen_retriever-0.2.1.tar.gz",
+        "sha256": "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/screen_retriever-0.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/screen_retriever-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c",
+        "contents": "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "screen_retriever-0.2.0.sha256"
+        "dest-filename": "screen_retriever-0.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/screen_retriever_linux-0.2.0.tar.gz",
-        "sha256": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "url": "https://pub.dev/api/archives/screen_retriever_linux-0.2.1.tar.gz",
+        "sha256": "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_linux-0.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_linux-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18",
+        "contents": "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "screen_retriever_linux-0.2.0.sha256"
+        "dest-filename": "screen_retriever_linux-0.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/screen_retriever_macos-0.2.0.tar.gz",
-        "sha256": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "url": "https://pub.dev/api/archives/screen_retriever_macos-0.2.1.tar.gz",
+        "sha256": "b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_macos-0.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_macos-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149",
+        "contents": "b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "screen_retriever_macos-0.2.0.sha256"
+        "dest-filename": "screen_retriever_macos-0.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/screen_retriever_platform_interface-0.2.0.tar.gz",
-        "sha256": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "url": "https://pub.dev/api/archives/screen_retriever_platform_interface-0.2.1.tar.gz",
+        "sha256": "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_platform_interface-0.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_platform_interface-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0",
+        "contents": "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "screen_retriever_platform_interface-0.2.0.sha256"
+        "dest-filename": "screen_retriever_platform_interface-0.2.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/screen_retriever_windows-0.2.0.tar.gz",
-        "sha256": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "url": "https://pub.dev/api/archives/screen_retriever_windows-0.2.1.tar.gz",
+        "sha256": "c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_windows-0.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/screen_retriever_windows-0.2.1"
     },
     {
         "type": "inline",
-        "contents": "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13",
+        "contents": "c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "screen_retriever_windows-0.2.0.sha256"
+        "dest-filename": "screen_retriever_windows-0.2.1.sha256"
     },
     {
         "type": "archive",
@@ -4507,16 +4507,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/shared_preferences_android-2.4.25.tar.gz",
-        "sha256": "a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0",
+        "url": "https://pub.dev/api/archives/shared_preferences_android-2.4.26.tar.gz",
+        "sha256": "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/shared_preferences_android-2.4.25"
+        "dest": ".pub-cache/hosted/pub.dev/shared_preferences_android-2.4.26"
     },
     {
         "type": "inline",
-        "contents": "a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0",
+        "contents": "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "shared_preferences_android-2.4.25.sha256"
+        "dest-filename": "shared_preferences_android-2.4.26.sha256"
     },
     {
         "type": "archive",
@@ -4829,16 +4829,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_common-2.5.9.tar.gz",
-        "sha256": "cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014",
+        "url": "https://pub.dev/api/archives/sqflite_common-2.5.11.tar.gz",
+        "sha256": "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.9"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_common-2.5.11"
     },
     {
         "type": "inline",
-        "contents": "cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014",
+        "contents": "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_common-2.5.9.sha256"
+        "dest-filename": "sqflite_common-2.5.11.sha256"
     },
     {
         "type": "archive",
@@ -5767,16 +5767,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/widgetbook-3.23.0.tar.gz",
-        "sha256": "4ff857b441b7fc43432a69ec6fe56494184c895e36cec502e400648024710b9c",
+        "url": "https://pub.dev/api/archives/widgetbook-3.24.0.tar.gz",
+        "sha256": "7ce2a15c59990610aefb0a8a4d69f67dd842d41676b7af6b5b746aa3371d32cf",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/widgetbook-3.23.0"
+        "dest": ".pub-cache/hosted/pub.dev/widgetbook-3.24.0"
     },
     {
         "type": "inline",
-        "contents": "4ff857b441b7fc43432a69ec6fe56494184c895e36cec502e400648024710b9c",
+        "contents": "7ce2a15c59990610aefb0a8a4d69f67dd842d41676b7af6b5b746aa3371d32cf",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "widgetbook-3.23.0.sha256"
+        "dest-filename": "widgetbook-3.24.0.sha256"
     },
     {
         "type": "archive",
@@ -6015,6 +6015,20 @@
         "contents": "82fa09800c0b71a2e8396bf3ca6b36b43cd35fe7ba2aeab53b6349ac671d0f5b",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "completion-1.0.2.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/coverage-1.15.0.tar.gz",
+        "sha256": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/coverage-1.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "coverage-1.15.0.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1022+4138` (upstream commit `9f6b2ca25685`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27506081526](https://github.com/matthiasn/lotti/actions/runs/27506081526).
