### PR TITLE
chore: 0.9.1022+4139

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9f6b2ca256850f528f089396818fa4e28c2e65ce
+        commit: 815f8d7ae31b5da73fdfc20b8da2a9947c068f45
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1022+4139` (upstream commit `815f8d7ae31b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27506933281](https://github.com/matthiasn/lotti/actions/runs/27506933281).
