### PR TITLE
chore: 0.9.1023+4140

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 815f8d7ae31b5da73fdfc20b8da2a9947c068f45
+        commit: 745d381fbe94f2aa75e973e85099650e405837f6
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1023+4140` (upstream commit `745d381fbe94`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27508972069](https://github.com/matthiasn/lotti/actions/runs/27508972069).
