### PR TITLE
chore: 0.9.1023+4141

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 815f8d7ae31b5da73fdfc20b8da2a9947c068f45
+        commit: 7ed3647e53361623a73919de7e5fb5de18aec422
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1023+4141` (upstream commit `7ed3647e5336`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27514319811](https://github.com/matthiasn/lotti/actions/runs/27514319811).
