### PR TITLE
chore: 0.9.1024+4142

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -113,7 +113,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 815f8d7ae31b5da73fdfc20b8da2a9947c068f45
+        commit: 3ec0483810ad5aaa0d2dbe8a72b52b235b896b82
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1024+4142` (upstream commit `3ec0483810ad`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27516406184](https://github.com/matthiasn/lotti/actions/runs/27516406184).
