### PR TITLE
chore: 0.9.1026+4144

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: 9d94b1e357c6f6cf4e98d03117606c70cf4d762c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1026+4144` (upstream commit `9d94b1e357c6`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27581066985](https://github.com/matthiasn/lotti/actions/runs/27581066985).
