### PR TITLE
chore: 0.9.1026+4145

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: 902782e815fb1c129ef559737b419488cd2f6966
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1026+4145` (upstream commit `902782e815fb`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27586745728](https://github.com/matthiasn/lotti/actions/runs/27586745728).
