### PR TITLE
chore: 0.9.1026+4146

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: b41b86b02d82df4ad177d92939e0bd4164d62b37
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1026+4146` (upstream commit `b41b86b02d82`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27615813458](https://github.com/matthiasn/lotti/actions/runs/27615813458).
