### PR TITLE
chore: 0.9.1026+4147

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: 4158177377f90e7bf0cd4c70e47f609dc881f368
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1026+4147` (upstream commit `4158177377f9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27707520175](https://github.com/matthiasn/lotti/actions/runs/27707520175).
