### PR TITLE
chore: 0.9.1027+4149

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: 9f5066bd7d30611dbb67814304597f6050c16667
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1027+4149` (upstream commit `9f5066bd7d30`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27749293597](https://github.com/matthiasn/lotti/actions/runs/27749293597).
