### PR TITLE
chore: 0.9.1027+4150

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: ac65795dc2646a173fe755ce6880d9a504fcf219
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1027+4150` (upstream commit `ac65795dc264`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27756269700](https://github.com/matthiasn/lotti/actions/runs/27756269700).
