### PR TITLE
chore: 0.9.1028+4151

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20c1b30a6691402e2031eae8b8dd10ecc66b07b8
+        commit: f9c8a56ec3743380a971f3b24213637933af629d
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1028+4151` (upstream commit `f9c8a56ec374`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27787676935](https://github.com/matthiasn/lotti/actions/runs/27787676935).
