### PR TITLE
chore: 0.9.1029+4155

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 7a5a4067d8c1398b6a2ef387bb046d084478703d
+        commit: 622783b966e0116995fb20e3d48429112a1c9233
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1029+4155` (upstream commit `622783b966e0`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27817353528](https://github.com/matthiasn/lotti/actions/runs/27817353528).
