### PR TITLE
chore: 0.9.1030+4158

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 13aeeaccdc12957706a04559240d05b9c7b2ef05
+        commit: 5ebd7a068a358da2f21d08d66c7b460f949068e0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1030+4158` (upstream commit `5ebd7a068a35`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27878330985](https://github.com/matthiasn/lotti/actions/runs/27878330985).
