### PR TITLE
chore: 0.9.1031+4162

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 89dff0ccf28a3b6bc583b1ef1faa522c9c0b57fa
+        commit: 3b13aa08c6a7746eb3653a22b5943e173c2bea01
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1031+4162` (upstream commit `3b13aa08c6a7`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27916280003](https://github.com/matthiasn/lotti/actions/runs/27916280003).
