### PR TITLE
chore: 0.9.1031+4163

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3b13aa08c6a7746eb3653a22b5943e173c2bea01
+        commit: a314062f0536d38e1b3bae34f7473ee2e3c6e692
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1031+4163` (upstream commit `a314062f0536`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#27986204007](https://github.com/matthiasn/lotti/actions/runs/27986204007).
