### PR TITLE
chore: 0.9.1031+4167

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b2dde59def1daee37d40ae154ff7c804a74ad536
+        commit: da0c0ed72b8c53976e4e09f9644e9424d9ea424e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -3122,16 +3122,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matrix-7.3.0.tar.gz",
-        "sha256": "c3c7168f79eb52dbf72cbe97ddd11d0f26bfbef324d669759abc86d8abdb4231",
+        "url": "https://pub.dev/api/archives/matrix-7.4.0.tar.gz",
+        "sha256": "cd08b966e02316e433723d137e1c9285bf65d51c087da78002f9fae3e9c734d7",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matrix-7.3.0"
+        "dest": ".pub-cache/hosted/pub.dev/matrix-7.4.0"
     },
     {
         "type": "inline",
-        "contents": "c3c7168f79eb52dbf72cbe97ddd11d0f26bfbef324d669759abc86d8abdb4231",
+        "contents": "cd08b966e02316e433723d137e1c9285bf65d51c087da78002f9fae3e9c734d7",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matrix-7.3.0.sha256"
+        "dest-filename": "matrix-7.4.0.sha256"
     },
     {
         "type": "archive",
@@ -3598,16 +3598,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/path_provider_linux-2.2.1.tar.gz",
-        "sha256": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "url": "https://pub.dev/api/archives/path_provider_linux-2.2.2.tar.gz",
+        "sha256": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/path_provider_linux-2.2.1"
+        "dest": ".pub-cache/hosted/pub.dev/path_provider_linux-2.2.2"
     },
     {
         "type": "inline",
-        "contents": "f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279",
+        "contents": "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "path_provider_linux-2.2.1.sha256"
+        "dest-filename": "path_provider_linux-2.2.2.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1031+4167` (upstream commit `da0c0ed72b8c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#28248036203](https://github.com/matthiasn/lotti/actions/runs/28248036203).
