### PR TITLE
chore: 0.9.1031+4169

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9519a59e5471cb05a02039c21ff13e9bcb3ca128
+        commit: be7dddc52b0201fc4a96e08956323accf5ed6113
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1031+4169` (upstream commit `be7dddc52b02`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#28264614155](https://github.com/matthiasn/lotti/actions/runs/28264614155).
