### PR TITLE
chore: 0.9.1031+4172

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 9519a59e5471cb05a02039c21ff13e9bcb3ca128
+        commit: 1c14f1b6d1f134d43287161091928f175216e1d1
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1031+4172` (upstream commit `1c14f1b6d1f1`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#28269401114](https://github.com/matthiasn/lotti/actions/runs/28269401114).
