### PR TITLE
chore: 0.9.1032+4181

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 6f6d04d629e48cd50badd090098542a8273f0e54
+        commit: f6461da32824ea98b348096afbf2ef073cc6bcf7
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1032+4181` (upstream commit `f6461da32824`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#28829025354](https://github.com/matthiasn/lotti/actions/runs/28829025354).
