### PR TITLE
chore: 0.9.1034+4185

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 22e7c34e4000077af17037324fd56bd682224519
+        commit: 1860cd5558751e48cddb50894d3ecba8545aba25
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -2086,6 +2086,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/gal-2.3.2.tar.gz",
+        "sha256": "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/gal-2.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "gal-2.3.2.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/genai_primitives-0.2.3.tar.gz",
         "sha256": "2468ecd2984f32232ab199315e384821c61a198e356828e34b9a5bcf0fda863e",
         "strip-components": 0,


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1034+4185` (upstream commit `1860cd555875`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#28884637585](https://github.com/matthiasn/lotti/actions/runs/28884637585).
