### PR TITLE
chore: 0.9.1036+4190

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 81f30b25f604fc63d0c2ed715836649d26caeaf0
+        commit: 34b7205476054169625a70f6a99cbb9cfe5f4235
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1036+4190` (upstream commit `34b720547605`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29006183691](https://github.com/matthiasn/lotti/actions/runs/29006183691).
