### PR TITLE
chore: 0.9.1036+4192

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 4fe49addf5d9b378f5ccbe2c919eb66caab228f1
+        commit: 3e8c92f261c993ff5bf395ba2716dcb9f03644b5
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1036+4192` (upstream commit `3e8c92f261c9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29025888023](https://github.com/matthiasn/lotti/actions/runs/29025888023).
