### PR TITLE
chore: 0.9.1037+4193

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3e8c92f261c993ff5bf395ba2716dcb9f03644b5
+        commit: 3bbccfee31bde71d2df97c0b9014cddd24deb74e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1037+4193` (upstream commit `3bbccfee31bd`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29079679901](https://github.com/matthiasn/lotti/actions/runs/29079679901).
