### PR TITLE
chore: 0.9.1037+4194

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3bbccfee31bde71d2df97c0b9014cddd24deb74e
+        commit: c247ff13900882d59d6af033e8e57f662545588b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1037+4194` (upstream commit `c247ff139008`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29151766077](https://github.com/matthiasn/lotti/actions/runs/29151766077).
