### PR TITLE
chore: 0.9.1037+4196

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3bbccfee31bde71d2df97c0b9014cddd24deb74e
+        commit: e8b715503f223d5ec67081b55610b2588ab3971c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1037+4196` (upstream commit `e8b715503f22`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29202163660](https://github.com/matthiasn/lotti/actions/runs/29202163660).
