### PR TITLE
chore: 0.9.1040+4199

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: ec61c64b38d656df19f5b2078e50a3c41368a8d6
+        commit: 2f2921226f66ae43a3627a357e24300b33d79a1a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1040+4199` (upstream commit `2f2921226f66`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29272968089](https://github.com/matthiasn/lotti/actions/runs/29272968089).
