### PR TITLE
chore: 0.9.1042+4203

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 7071b126a904a5db016838f6b300d49b43b76a39
+        commit: a3fff038dc3acdf7f7a0abcd013274f798a0e560
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1042+4203` (upstream commit `a3fff038dc3a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29288138394](https://github.com/matthiasn/lotti/actions/runs/29288138394).
