### PR TITLE
chore: 0.9.1043+4204

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 7071b126a904a5db016838f6b300d49b43b76a39
+        commit: 43d86b94dc30ccb4900bb34d9a21dd542e211322
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -128,6 +128,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/audio_decoder-0.8.1.tar.gz",
+        "sha256": "116d71853a934ede4d2afe31a1dabfb9fe5bb50efe3df4d798dc546cf6604c9f",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/audio_decoder-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "116d71853a934ede4d2afe31a1dabfb9fe5bb50efe3df4d798dc546cf6604c9f",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "audio_decoder-0.8.1.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/audio_session-0.1.25.tar.gz",
         "sha256": "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac",
         "strip-components": 0,


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1043+4204` (upstream commit `43d86b94dc30`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29291012736](https://github.com/matthiasn/lotti/actions/runs/29291012736).
