### PR TITLE
chore: 0.9.1047+4212

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b0a7dc827eccf5a8b7a881335ed77bc080dfb5ba
+        commit: 87430c6b8342f6b4846a2684c4437f282f7f576c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -2310,76 +2310,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hotkey_manager-0.2.3.tar.gz",
-        "sha256": "06f0655b76c8dd322fb7101dc615afbdbf39c3d3414df9e059c33892104479cd",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hotkey_manager-0.2.3"
-    },
-    {
-        "type": "inline",
-        "contents": "06f0655b76c8dd322fb7101dc615afbdbf39c3d3414df9e059c33892104479cd",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hotkey_manager-0.2.3.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hotkey_manager_linux-0.2.0.tar.gz",
-        "sha256": "83676bda8210a3377bc6f1977f193bc1dbdd4c46f1bdd02875f44b6eff9a8473",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hotkey_manager_linux-0.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "83676bda8210a3377bc6f1977f193bc1dbdd4c46f1bdd02875f44b6eff9a8473",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hotkey_manager_linux-0.2.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hotkey_manager_macos-0.2.0.tar.gz",
-        "sha256": "03b5967e64357b9ac05188ea4a5df6fe4ed4205762cb80aaccf8916ee1713c96",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hotkey_manager_macos-0.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "03b5967e64357b9ac05188ea4a5df6fe4ed4205762cb80aaccf8916ee1713c96",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hotkey_manager_macos-0.2.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hotkey_manager_platform_interface-0.2.0.tar.gz",
-        "sha256": "98ffca25b8cc9081552902747b2942e3bc37855389a4218c9d50ca316b653b13",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hotkey_manager_platform_interface-0.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "98ffca25b8cc9081552902747b2942e3bc37855389a4218c9d50ca316b653b13",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hotkey_manager_platform_interface-0.2.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hotkey_manager_windows-0.2.0.tar.gz",
-        "sha256": "0d03ced9fe563ed0b68f0a0e1b22c9ffe26eb8053cb960e401f68a4f070e0117",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hotkey_manager_windows-0.2.0"
-    },
-    {
-        "type": "inline",
-        "contents": "0d03ced9fe563ed0b68f0a0e1b22c9ffe26eb8053cb960e401f68a4f070e0117",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hotkey_manager_windows-0.2.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/html-0.15.6.tar.gz",
         "sha256": "6d1264f2dffa1b1101c25a91dff0dc2daee4c18e87cd8538729773c073dbf602",
         "strip-components": 0,
@@ -5161,20 +5091,6 @@
         "contents": "f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "typed_data-1.4.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/uni_platform-0.1.3.tar.gz",
-        "sha256": "e02213a7ee5352212412ca026afd41d269eb00d982faa552f419ffc2debfad84",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/uni_platform-0.1.3"
-    },
-    {
-        "type": "inline",
-        "contents": "e02213a7ee5352212412ca026afd41d269eb00d982faa552f419ffc2debfad84",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "uni_platform-0.1.3.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1047+4212` (upstream commit `87430c6b8342`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29445601202](https://github.com/matthiasn/lotti/actions/runs/29445601202).
