### PR TITLE
chore: 0.9.1047+4214

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 87430c6b8342f6b4846a2684c4437f282f7f576c
+        commit: 75d6647b47f5a49bf19c48ddb4be6cc99d4bbdac
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1047+4214` (upstream commit `75d6647b47f5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29451995195](https://github.com/matthiasn/lotti/actions/runs/29451995195).
