### PR TITLE
chore: 0.9.1048+4215

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 75d6647b47f5a49bf19c48ddb4be6cc99d4bbdac
+        commit: e00c753675e7b3d5df1f4b792b5bc349b7c07c56
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1048+4215` (upstream commit `e00c753675e7`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29478767880](https://github.com/matthiasn/lotti/actions/runs/29478767880).
