### PR TITLE
chore: 0.9.1048+4216

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e00c753675e7b3d5df1f4b792b5bc349b7c07c56
+        commit: 0ae72d28e040d0deb14c9220f7553783d5c13e41
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1048+4216` (upstream commit `0ae72d28e040`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29485375718](https://github.com/matthiasn/lotti/actions/runs/29485375718).
