### PR TITLE
chore: 0.9.1051+4219

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: d7e5fd0042790fc74659b6935fe0f0282ef0c3b9
+        commit: eb6516bf91ec891b5a4deacdb74d6d960bb25459
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1051+4219` (upstream commit `eb6516bf91ec`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29572898056](https://github.com/matthiasn/lotti/actions/runs/29572898056).
