### PR TITLE
chore: 0.9.1051+4220

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: eb6516bf91ec891b5a4deacdb74d6d960bb25459
+        commit: ca733b62fd2d82876ee7e8b76e4763aefb4f6e23
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1051+4220` (upstream commit `ca733b62fd2d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29576487358](https://github.com/matthiasn/lotti/actions/runs/29576487358).
