### PR TITLE
chore: 0.9.1051+4222

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 39d20acf1b4bd6de8b5bd4fbe567cecc5f1a7417
+        commit: 616f05ae928c3e7b561b0b6b6220f392d0c36b4c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1051+4222` (upstream commit `616f05ae928c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29603890139](https://github.com/matthiasn/lotti/actions/runs/29603890139).
