### PR TITLE
chore: 0.9.1051+4223

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 39d20acf1b4bd6de8b5bd4fbe567cecc5f1a7417
+        commit: d4c5526a1d2f7957a3f92e62ff36d4453c5271aa
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1051+4223` (upstream commit `d4c5526a1d2f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29614867695](https://github.com/matthiasn/lotti/actions/runs/29614867695).
