### PR TITLE
chore: 0.9.1054+4226

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 032b01c49c2b3381dfb80bcf5d5fd1c9fd8367ce
+        commit: d8b4adb4ccda0f330bb6ee7813c5a22d82c70258
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1054+4226` (upstream commit `d8b4adb4ccda`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29655403202](https://github.com/matthiasn/lotti/actions/runs/29655403202).
