### PR TITLE
chore: 0.9.1054+4227

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 58b1a59d22b41ef586cd614185b577fcf368ddf8
+        commit: d8af4f2ed98fa4dc8a4f42a799540951825b9e4e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1054+4227` (upstream commit `d8af4f2ed98f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29657093940](https://github.com/matthiasn/lotti/actions/runs/29657093940).
