### PR TITLE
chore: 0.9.1054+4229

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -131,7 +131,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 20a43fdc2ace5e905f0403a88b86a7e0f21a1fd8
+        commit: 957f1d428433f96c071657e31aec219940bc3c87
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1054+4229` (upstream commit `957f1d428433`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29717220823](https://github.com/matthiasn/lotti/actions/runs/29717220823).
