### PR TITLE
chore: 0.9.1056+4231

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -17,6 +17,7 @@ finish-args:
   - --filesystem=xdg-documents/Lotti:create
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download/Lotti:create
+  - --talk-name=org.freedesktop.secrets
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 modules:
   - name: python3-jinja2
@@ -131,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 0cf189c5b1b6a3c3a9658bd8abda3397b349008f
+        commit: d4bd3445ecdf920255a21b66cd1eae423fb7080f
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1056+4231` (upstream commit `d4bd3445ecdf`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29779314403](https://github.com/matthiasn/lotti/actions/runs/29779314403).
