### PR TITLE
chore: 0.9.1058+4233

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 89d9251bdf43601e02f39878da90b592bfdcac29
+        commit: afb2af279d4399726f91a97c13a72a9a7ee6a35a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1058+4233` (upstream commit `afb2af279d43`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29880108257](https://github.com/matthiasn/lotti/actions/runs/29880108257).
