### PR TITLE
chore: 0.9.1060+4235

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: afb2af279d4399726f91a97c13a72a9a7ee6a35a
+        commit: d08385d774c71e83dca06d4a9adb37e2e22fdcd3
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1060+4235` (upstream commit `d08385d774c7`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29912497646](https://github.com/matthiasn/lotti/actions/runs/29912497646).
