### PR TITLE
chore: 0.9.1060+4238

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5f1471202e2728901da2da2dde8ad6edaf9b2862
+        commit: b849ac9621ea9d8ad5d83a710a3e3734a7008cf4
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1060+4238` (upstream commit `b849ac9621ea`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#29962464890](https://github.com/matthiasn/lotti/actions/runs/29962464890).
