### PR TITLE
chore: 0.9.1061+4239

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: b849ac9621ea9d8ad5d83a710a3e3734a7008cf4
+        commit: 2b32d5048504c5d79cb2f79b960203b070570f5b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1061+4239` (upstream commit `2b32d5048504`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30001129664](https://github.com/matthiasn/lotti/actions/runs/30001129664).
