### PR TITLE
chore: 0.9.1062+4240

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2b32d5048504c5d79cb2f79b960203b070570f5b
+        commit: a5152bc4ec5c5aa53077ef33f3f223b5e76d7dc0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1062+4240` (upstream commit `a5152bc4ec5c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30049066687](https://github.com/matthiasn/lotti/actions/runs/30049066687).
