### PR TITLE
chore: 0.9.1062+4241

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: a5152bc4ec5c5aa53077ef33f3f223b5e76d7dc0
+        commit: 3fe837f5d3098338b2ad3999285a34514fc41f8a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1062+4241` (upstream commit `3fe837f5d309`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30053306985](https://github.com/matthiasn/lotti/actions/runs/30053306985).
