### PR TITLE
chore: 0.9.1064+4244

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3fe837f5d3098338b2ad3999285a34514fc41f8a
+        commit: 54025ccd1d9634bef71471236af323b74d2bddc0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -4549,20 +4549,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/siri_wave-2.3.1.tar.gz",
-        "sha256": "ea815d6627dc297f6be883bb0dd7a579a5f5f9729242d47c10e95850cccf169a",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/siri_wave-2.3.1"
-    },
-    {
-        "type": "inline",
-        "contents": "ea815d6627dc297f6be883bb0dd7a579a5f5f9729242d47c10e95850cccf169a",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "siri_wave-2.3.1.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/sliver_tools-0.2.12.tar.gz",
         "sha256": "eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6",
         "strip-components": 0,


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1064+4244` (upstream commit `54025ccd1d96`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30133949354](https://github.com/matthiasn/lotti/actions/runs/30133949354).
