### PR TITLE
chore: 0.9.1068+4249

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 069eddefc32a2b0c8da6c5386493a27ef1481f60
+        commit: fa842e6bcd0d8d0299a8b8af136161218e21e815
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1068+4249` (upstream commit `fa842e6bcd0d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30158568612](https://github.com/matthiasn/lotti/actions/runs/30158568612).
