### PR TITLE
chore: 0.9.1069+4253

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: fa842e6bcd0d8d0299a8b8af136161218e21e815
+        commit: 0183b5e2c8b260ca959412e934483ca18d08e132
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1069+4253` (upstream commit `0183b5e2c8b2`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30170401917](https://github.com/matthiasn/lotti/actions/runs/30170401917).
