### PR TITLE
chore: 0.9.1069+4255

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 0183b5e2c8b260ca959412e934483ca18d08e132
+        commit: ff66a709a9342a8cbabaa17f4d62f3bbae38d838
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1069+4255` (upstream commit `ff66a709a934`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30173343178](https://github.com/matthiasn/lotti/actions/runs/30173343178).
