### PR TITLE
chore: 0.9.1070+4258

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 4d3b371e19c5fbc651707ea95e2680703396e51e
+        commit: 86356a105c925ab5e9d347cfabdae2ed975f264a
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1070+4258` (upstream commit `86356a105c92`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30202468562](https://github.com/matthiasn/lotti/actions/runs/30202468562).
