### PR TITLE
chore: 0.9.1071+4261

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: d54d4b8a1baeff195f2212e9dce8e1db9774c259
+        commit: 52021bb2d23fc7a66c806a2d8358bbe3a1262b0d
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1071+4261` (upstream commit `52021bb2d23f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30218133817](https://github.com/matthiasn/lotti/actions/runs/30218133817).
