### PR TITLE
chore: 0.9.1071+4265

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c766e43a341f5aa5c1e0188355098178136b1ef8
+        commit: 4557758caefc436327af505649275dbbadb72e4b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1071+4265` (upstream commit `4557758caefc`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30292798372](https://github.com/matthiasn/lotti/actions/runs/30292798372).
