### PR TITLE
chore: 0.9.1071+4266

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 4557758caefc436327af505649275dbbadb72e4b
+        commit: aa7fa4d19b94e5af8e59a346ecbd40b48a9740c3
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1071+4266` (upstream commit `aa7fa4d19b94`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30310984182](https://github.com/matthiasn/lotti/actions/runs/30310984182).
