### PR TITLE
chore: 0.9.1071+4269

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 93b0b48c56aa83df9492ce94b37f0e7d0f1e0d91
+        commit: 3ca84530a89341d5e7c94b915989cd93c3b8c3fc
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1071+4269` (upstream commit `3ca84530a893`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30423764469](https://github.com/matthiasn/lotti/actions/runs/30423764469).
