### PR TITLE
chore: 0.9.1071+4270

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 93b0b48c56aa83df9492ce94b37f0e7d0f1e0d91
+        commit: f02d3185201de1e149ba85b4fc54c2b2ec6ef966
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1071+4270` (upstream commit `f02d3185201d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30446120025](https://github.com/matthiasn/lotti/actions/runs/30446120025).
