### PR TITLE
chore: 0.9.1072+4271

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 93b0b48c56aa83df9492ce94b37f0e7d0f1e0d91
+        commit: 27e19d865a83322986dda20847e3c67d51610357
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1072+4271` (upstream commit `27e19d865a83`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30470965796](https://github.com/matthiasn/lotti/actions/runs/30470965796).
