### PR TITLE
chore: 0.9.1072+4272

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 93b0b48c56aa83df9492ce94b37f0e7d0f1e0d91
+        commit: 33dfa1dc5a48a7c6272d22e2e29f73e443efeffb
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1072+4272` (upstream commit `33dfa1dc5a48`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30478497562](https://github.com/matthiasn/lotti/actions/runs/30478497562).
