### PR TITLE
chore: 0.9.1073+4273

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 33dfa1dc5a48a7c6272d22e2e29f73e443efeffb
+        commit: 3daec3e48d7b216af8f9532d528a1b3f99a43ac7
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1073+4273` (upstream commit `3daec3e48d7b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30495805506](https://github.com/matthiasn/lotti/actions/runs/30495805506).
