### PR TITLE
chore: 0.9.1073+4274

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 3daec3e48d7b216af8f9532d528a1b3f99a43ac7
+        commit: b8d47e91ef3de07a2bac3629e13a9d5cbe27e855
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh
@@ -143,4 +143,4 @@ modules:
       - generated/sources/pubspec.json
     modules:
       - generated/modules/rustup-1.91.1.json
-      - generated/modules/flutter-sdk-3.44.0.json
+      - generated/modules/flutter-sdk-3.44.8.json

--- a/generated/modules/flutter-sdk-3.44.8.json
+++ b/generated/modules/flutter-sdk-3.44.8.json
@@ -1,0 +1,176 @@
+{
+    "name": "flutter",
+    "buildsystem": "simple",
+    "build-commands": [
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine-dart-sdk.stamp",
+        "cp flutter/bin/internal/material_fonts.version flutter/bin/cache/material_fonts.stamp",
+        "cp flutter/bin/internal/gradle_wrapper.version flutter/bin/cache/gradle_wrapper.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine_stamp.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/flutter_sdk.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/font-subset.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/linux-sdk.stamp",
+        "mkdir -p /var/lib && cp -r flutter /var/lib"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/flutter/flutter.git",
+            "tag": "3.44.8",
+            "commit": "058e0af2c2b57e369d905a03ac9748b0ebf543c6",
+            "dest": "flutter"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/dart-sdk-linux-x64.zip",
+            "sha256": "04069d912c86810cee252febfdaddf1e84b9ec36d359ff44e7405787e82adfe5",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/dart-sdk-linux-arm64.zip",
+            "sha256": "7eddd549b0d4e4aae48175642caee6023ed5d2aeaf2d12cb9455d0ee1fdbcaf5",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3012db47f3130e62f7cc0beabff968a33cbec8d8/fonts.zip",
+            "sha256": "e56fa8e9bb4589fde964be3de451f3e5b251e4a1eafb1dc98d94add034dd5a86",
+            "dest": "flutter/bin/cache/artifacts/material_fonts"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz",
+            "sha256": "31e9428baf1a2b2f485f1110c5899f852649b33d46a2e9b07f9d17752d50190a",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/gradle_wrapper"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/sky_engine.zip",
+            "sha256": "43ac2e00b159969b484ca35aac99de79e214cf9e91bc82eb3b5c28522a09578b",
+            "dest": "flutter/bin/cache/pkg/sky_engine"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/flutter_gpu.zip",
+            "sha256": "3d7d41e3cb7e8ed16242b24c8f3d83ccf5e0efb68869fbd1281557e5a4ba67c7",
+            "dest": "flutter/bin/cache/pkg/flutter_gpu"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/flutter_patched_sdk.zip",
+            "sha256": "f3fbe95e339c356fbf99427583cd42748eb48e849554d702bc262fe1948a0798",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/flutter_patched_sdk_product.zip",
+            "sha256": "2e4b89e96dc74245b8d072fceadcaa4b0a25649b9461be525081538262f95a5a",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk_product"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-x64/artifacts.zip",
+            "sha256": "f4f089747953540500b0bf67067ea73c644a004a87dc6ceefdee5f6661d486ed",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-x64/font-subset.zip",
+            "sha256": "4a194c950eda20782af0c40e68498038eb6ca759fce386bae49b6ca1caff927e",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-x64-profile/linux-x64-flutter-gtk.zip",
+            "sha256": "e4865b1c9a5deaa8f137241479dfba90d23692835c10d7f3be88220d1206eae9",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-x64-release/linux-x64-flutter-gtk.zip",
+            "sha256": "b30a83784542fdacfe8a385a664d9efbd1d82f02cf3d7cabd35b7180e1138db7",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-release"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-arm64/artifacts.zip",
+            "sha256": "169f719e34abffb7a00c863d6f30ee558b92de5fd5d283001d79de5f8abc2e0f",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-arm64/font-subset.zip",
+            "sha256": "0051a6fe2ef93719651c88dc914039dc4d3f55be33dc00523418ec7687d595c4",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-arm64-profile/linux-arm64-flutter-gtk.zip",
+            "sha256": "65c081ae9ccf6a6ee6a9997dac3053e06cedeeeedb3ca4ad26cd012b3ea1a453",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/linux-arm64-release/linux-arm64-flutter-gtk.zip",
+            "sha256": "1c2597c0bbc6fd591b0e436ae5359dbe28d19ab32a6284ac6d6900208c03d989",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-release"
+        },
+        {
+            "type": "patch",
+            "path": "../patches/flutter/shared.sh.patch"
+        },
+        {
+            "type": "script",
+            "dest": "flutter/bin",
+            "dest-filename": "setup-flutter.sh",
+            "commands": [
+                "flutter pub get --offline $@"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/0cd610717bde95fd88343c64f81c11ba4e5c0010/engine_stamp.json",
+            "sha256": "721d0632bbe75d93e46e1f435a56bd45ddee9d1d01693209ade81915a21c1968",
+            "dest": "flutter/bin/cache"
+        }
+    ]
+}

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -338,30 +338,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/build_config-1.3.1.tar.gz",
-        "sha256": "f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae",
+        "url": "https://pub.dev/api/archives/build_config-1.3.2.tar.gz",
+        "sha256": "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/build_config-1.3.1"
+        "dest": ".pub-cache/hosted/pub.dev/build_config-1.3.2"
     },
     {
         "type": "inline",
-        "contents": "f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae",
+        "contents": "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "build_config-1.3.1.sha256"
+        "dest-filename": "build_config-1.3.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/build_daemon-4.1.2.tar.gz",
-        "sha256": "fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78",
+        "url": "https://pub.dev/api/archives/build_daemon-4.1.3.tar.gz",
+        "sha256": "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/build_daemon-4.1.2"
+        "dest": ".pub-cache/hosted/pub.dev/build_daemon-4.1.3"
     },
     {
         "type": "inline",
-        "contents": "fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78",
+        "contents": "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "build_daemon-4.1.2.sha256"
+        "dest-filename": "build_daemon-4.1.3.sha256"
     },
     {
         "type": "archive",
@@ -618,16 +618,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/connectivity_plus-7.3.0.tar.gz",
-        "sha256": "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb",
+        "url": "https://pub.dev/api/archives/connectivity_plus-7.3.1.tar.gz",
+        "sha256": "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/connectivity_plus-7.3.0"
+        "dest": ".pub-cache/hosted/pub.dev/connectivity_plus-7.3.1"
     },
     {
         "type": "inline",
-        "contents": "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb",
+        "contents": "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "connectivity_plus-7.3.0.sha256"
+        "dest-filename": "connectivity_plus-7.3.1.sha256"
     },
     {
         "type": "archive",
@@ -926,16 +926,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/decimal-3.2.5.tar.gz",
-        "sha256": "4988f89bbbf9de235430300d5ee0e8e87c733a56145dc7d0dd97e6cf90cf809b",
+        "url": "https://pub.dev/api/archives/decimal-3.2.6.tar.gz",
+        "sha256": "2c3c8b74f2948066d3f42585477aec9cfc48fefd7a723a4d4274a6c71a5c0df7",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/decimal-3.2.5"
+        "dest": ".pub-cache/hosted/pub.dev/decimal-3.2.6"
     },
     {
         "type": "inline",
-        "contents": "4988f89bbbf9de235430300d5ee0e8e87c733a56145dc7d0dd97e6cf90cf809b",
+        "contents": "2c3c8b74f2948066d3f42585477aec9cfc48fefd7a723a4d4274a6c71a5c0df7",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "decimal-3.2.5.sha256"
+        "dest-filename": "decimal-3.2.6.sha256"
     },
     {
         "type": "git",
@@ -1205,16 +1205,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/file_selector_android-0.5.2+8.tar.gz",
-        "sha256": "6a26687fa65cbc28a5345c7ae6f227e89f0b47740978a4c475b1a625da7a331b",
+        "url": "https://pub.dev/api/archives/file_selector_android-0.5.2+9.tar.gz",
+        "sha256": "1d45e9910f68c16eb0c74f0b10097ad81aed516ea28054c027137e8f7d75e840",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/file_selector_android-0.5.2+8"
+        "dest": ".pub-cache/hosted/pub.dev/file_selector_android-0.5.2+9"
     },
     {
         "type": "inline",
-        "contents": "6a26687fa65cbc28a5345c7ae6f227e89f0b47740978a4c475b1a625da7a331b",
+        "contents": "1d45e9910f68c16eb0c74f0b10097ad81aed516ea28054c027137e8f7d75e840",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "file_selector_android-0.5.2+8.sha256"
+        "dest-filename": "file_selector_android-0.5.2+9.sha256"
     },
     {
         "type": "archive",
@@ -1443,30 +1443,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_image_compress-2.5.0.tar.gz",
-        "sha256": "e7c48e0832f52ae65e775bf0d2324447a1781ed6d7e55a6c4136046ad44f2f22",
+        "url": "https://pub.dev/api/archives/flutter_image_compress-2.5.1.tar.gz",
+        "sha256": "98a48c05a7add6869c6838270e862124a4d571f9dd5d0cf209ed03a71b20ea84",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_image_compress-2.5.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_image_compress-2.5.1"
     },
     {
         "type": "inline",
-        "contents": "e7c48e0832f52ae65e775bf0d2324447a1781ed6d7e55a6c4136046ad44f2f22",
+        "contents": "98a48c05a7add6869c6838270e862124a4d571f9dd5d0cf209ed03a71b20ea84",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_image_compress-2.5.0.sha256"
+        "dest-filename": "flutter_image_compress-2.5.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_image_compress_common-1.1.0.tar.gz",
-        "sha256": "10520a2d4bade23d31ba5a4b9f56fa7d11b6a62f11fe3576106c1867cc10dcf6",
+        "url": "https://pub.dev/api/archives/flutter_image_compress_common-1.1.1.tar.gz",
+        "sha256": "76869e4d5f3d65f3431e7edff0b2d8ad1eea68b49c6a37772fdb1ae6016da9ed",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_image_compress_common-1.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_image_compress_common-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "10520a2d4bade23d31ba5a4b9f56fa7d11b6a62f11fe3576106c1867cc10dcf6",
+        "contents": "76869e4d5f3d65f3431e7edff0b2d8ad1eea68b49c6a37772fdb1ae6016da9ed",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_image_compress_common-1.1.0.sha256"
+        "dest-filename": "flutter_image_compress_common-1.1.1.sha256"
     },
     {
         "type": "archive",
@@ -1638,16 +1638,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_local_notifications-22.1.0.tar.gz",
-        "sha256": "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6",
+        "url": "https://pub.dev/api/archives/flutter_local_notifications-22.2.0.tar.gz",
+        "sha256": "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_local_notifications-22.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_local_notifications-22.2.0"
     },
     {
         "type": "inline",
-        "contents": "40c6a69189a622bda89ddcf50a139f4ba0f0eb9c0fef6718845b1f8b95452ed6",
+        "contents": "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_local_notifications-22.1.0.sha256"
+        "dest-filename": "flutter_local_notifications-22.2.0.sha256"
     },
     {
         "type": "archive",
@@ -1666,16 +1666,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_local_notifications_platform_interface-12.0.1.tar.gz",
-        "sha256": "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852",
+        "url": "https://pub.dev/api/archives/flutter_local_notifications_platform_interface-12.1.0.tar.gz",
+        "sha256": "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_local_notifications_platform_interface-12.0.1"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_local_notifications_platform_interface-12.1.0"
     },
     {
         "type": "inline",
-        "contents": "4dfbae10debab9ac975d8b01943fed94c0c19dad43f825964b29f3c3f9a8a852",
+        "contents": "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_local_notifications_platform_interface-12.0.1.sha256"
+        "dest-filename": "flutter_local_notifications_platform_interface-12.1.0.sha256"
     },
     {
         "type": "archive",
@@ -1862,16 +1862,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_riverpod-3.3.2.tar.gz",
-        "sha256": "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e",
+        "url": "https://pub.dev/api/archives/flutter_riverpod-3.4.2.tar.gz",
+        "sha256": "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_riverpod-3.3.2"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_riverpod-3.4.2"
     },
     {
         "type": "inline",
-        "contents": "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e",
+        "contents": "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_riverpod-3.3.2.sha256"
+        "dest-filename": "flutter_riverpod-3.4.2.sha256"
     },
     {
         "type": "archive",
@@ -1932,16 +1932,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage_platform_interface-2.0.1.tar.gz",
-        "sha256": "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage_platform_interface-2.0.2.tar.gz",
+        "sha256": "06686df417f34fe9f963ed217b7fdce250e2f637ddd6c374d7eb054549770633",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_platform_interface-2.0.1"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_platform_interface-2.0.2"
     },
     {
         "type": "inline",
-        "contents": "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6",
+        "contents": "06686df417f34fe9f963ed217b7fdce250e2f637ddd6c374d7eb054549770633",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage_platform_interface-2.0.1.sha256"
+        "dest-filename": "flutter_secure_storage_platform_interface-2.0.2.sha256"
     },
     {
         "type": "archive",
@@ -2114,16 +2114,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/gal-2.3.2.tar.gz",
-        "sha256": "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee",
+        "url": "https://pub.dev/api/archives/gal-2.3.3.tar.gz",
+        "sha256": "f71e79840fe023a21f2f949771375444b6efcd34b9e625d5f4f5504971380a77",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/gal-2.3.2"
+        "dest": ".pub-cache/hosted/pub.dev/gal-2.3.3"
     },
     {
         "type": "inline",
-        "contents": "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee",
+        "contents": "f71e79840fe023a21f2f949771375444b6efcd34b9e625d5f4f5504971380a77",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "gal-2.3.2.sha256"
+        "dest-filename": "gal-2.3.3.sha256"
     },
     {
         "type": "archive",
@@ -2646,30 +2646,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/jni-1.0.0.tar.gz",
-        "sha256": "c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f",
+        "url": "https://pub.dev/api/archives/is_ios_simulator-1.0.1.tar.gz",
+        "sha256": "01321f4f778ec931b5abc216e6922dccf51e3c5db8aef72b3874f6b4c5447374",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/jni-1.0.0"
+        "dest": ".pub-cache/hosted/pub.dev/is_ios_simulator-1.0.1"
     },
     {
         "type": "inline",
-        "contents": "c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f",
+        "contents": "01321f4f778ec931b5abc216e6922dccf51e3c5db8aef72b3874f6b4c5447374",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "jni-1.0.0.sha256"
+        "dest-filename": "is_ios_simulator-1.0.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/jni_flutter-1.0.1.tar.gz",
-        "sha256": "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6",
+        "url": "https://pub.dev/api/archives/jni-1.0.3.tar.gz",
+        "sha256": "f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/jni_flutter-1.0.1"
+        "dest": ".pub-cache/hosted/pub.dev/jni-1.0.3"
     },
     {
         "type": "inline",
-        "contents": "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6",
+        "contents": "f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "jni_flutter-1.0.1.sha256"
+        "dest-filename": "jni-1.0.3.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/jni_flutter-1.0.2.tar.gz",
+        "sha256": "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/jni_flutter-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "jni_flutter-1.0.2.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/jni_util-1.0.0.tar.gz",
+        "sha256": "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/jni_util-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "jni_util-1.0.0.sha256"
     },
     {
         "type": "archive",
@@ -2758,16 +2786,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/json_serializable-6.14.0.tar.gz",
-        "sha256": "ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501",
+        "url": "https://pub.dev/api/archives/json_serializable-6.14.1.tar.gz",
+        "sha256": "e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/json_serializable-6.14.0"
+        "dest": ".pub-cache/hosted/pub.dev/json_serializable-6.14.1"
     },
     {
         "type": "inline",
-        "contents": "ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501",
+        "contents": "e45aefa0324f08c683caafbb94b72837aa6193c61822799c916e45f4a263113d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "json_serializable-6.14.0.sha256"
+        "dest-filename": "json_serializable-6.14.1.sha256"
     },
     {
         "type": "archive",
@@ -2894,6 +2922,20 @@
         "contents": "4139ea77f4651ab9c315b577da2dd108d9aa0bd84b5d03d33323f1970c645832",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "linkify-5.0.0.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/listen-1.0.0-beta.4.tar.gz",
+        "sha256": "cb0ad74d7453d8f83a7c1fae401828681ef5df21d41a3a26a04af590c985d085",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/listen-1.0.0-beta.4"
+    },
+    {
+        "type": "inline",
+        "contents": "cb0ad74d7453d8f83a7c1fae401828681ef5df21d41a3a26a04af590c985d085",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "listen-1.0.0-beta.4.sha256"
     },
     {
         "type": "archive",
@@ -3598,16 +3640,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/photo_manager-3.10.0.tar.gz",
-        "sha256": "bf840253a7a5a48774f3a23b042a673614785e9874e0c86e2837681d576ef252",
+        "url": "https://pub.dev/api/archives/photo_manager-3.11.0.tar.gz",
+        "sha256": "4f7de6c9778993c5c54cf1fb2eaa8d5c27c0771dc24a4dfca341aa81aef13fe1",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/photo_manager-3.10.0"
+        "dest": ".pub-cache/hosted/pub.dev/photo_manager-3.11.0"
     },
     {
         "type": "inline",
-        "contents": "bf840253a7a5a48774f3a23b042a673614785e9874e0c86e2837681d576ef252",
+        "contents": "4f7de6c9778993c5c54cf1fb2eaa8d5c27c0771dc24a4dfca341aa81aef13fe1",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "photo_manager-3.10.0.sha256"
+        "dest-filename": "photo_manager-3.11.0.sha256"
     },
     {
         "type": "archive",
@@ -3738,16 +3780,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/posix-6.5.0.tar.gz",
-        "sha256": "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07",
+        "url": "https://pub.dev/api/archives/posix-6.5.2.tar.gz",
+        "sha256": "bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/posix-6.5.0"
+        "dest": ".pub-cache/hosted/pub.dev/posix-6.5.2"
     },
     {
         "type": "inline",
-        "contents": "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07",
+        "contents": "bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "posix-6.5.0.sha256"
+        "dest-filename": "posix-6.5.2.sha256"
     },
     {
         "type": "archive",
@@ -3892,30 +3934,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/quill_native_bridge_android-0.0.1+2.tar.gz",
-        "sha256": "b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569",
+        "url": "https://pub.dev/api/archives/quill_native_bridge_android-0.0.2.tar.gz",
+        "sha256": "763f2066d252a10c04cc66add7b7fa967bae8d25aefcd180d5ac808f5af4d143",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/quill_native_bridge_android-0.0.1+2"
+        "dest": ".pub-cache/hosted/pub.dev/quill_native_bridge_android-0.0.2"
     },
     {
         "type": "inline",
-        "contents": "b75c7e6ede362a7007f545118e756b1f19053994144ec9eda932ce5e54a57569",
+        "contents": "763f2066d252a10c04cc66add7b7fa967bae8d25aefcd180d5ac808f5af4d143",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "quill_native_bridge_android-0.0.1+2.sha256"
+        "dest-filename": "quill_native_bridge_android-0.0.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/quill_native_bridge_ios-0.0.1.tar.gz",
-        "sha256": "d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f",
+        "url": "https://pub.dev/api/archives/quill_native_bridge_ios-0.0.3.tar.gz",
+        "sha256": "31f9a0a955f85fbcd2576fdb6feb1879c70d770980d7f0118b7f2c0621c6b745",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/quill_native_bridge_ios-0.0.1"
+        "dest": ".pub-cache/hosted/pub.dev/quill_native_bridge_ios-0.0.3"
     },
     {
         "type": "inline",
-        "contents": "d23de3cd7724d482fe2b514617f8eedc8f296e120fb297368917ac3b59d8099f",
+        "contents": "31f9a0a955f85fbcd2576fdb6feb1879c70d770980d7f0118b7f2c0621c6b745",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "quill_native_bridge_ios-0.0.1.sha256"
+        "dest-filename": "quill_native_bridge_ios-0.0.3.sha256"
     },
     {
         "type": "archive",
@@ -4116,30 +4158,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_web-2.1.1.tar.gz",
-        "sha256": "7d75ed681b5bf40c3a9b51b6c105fe53705f752284d859d5f030ab5a2bfd49cf",
+        "url": "https://pub.dev/api/archives/record_web-2.1.2.tar.gz",
+        "sha256": "f53d3da48de3618a331868aec73261d5a75eddd9c09409afd9ec6d66b25db532",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_web-2.1.1"
+        "dest": ".pub-cache/hosted/pub.dev/record_web-2.1.2"
     },
     {
         "type": "inline",
-        "contents": "7d75ed681b5bf40c3a9b51b6c105fe53705f752284d859d5f030ab5a2bfd49cf",
+        "contents": "f53d3da48de3618a331868aec73261d5a75eddd9c09409afd9ec6d66b25db532",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_web-2.1.1.sha256"
+        "dest-filename": "record_web-2.1.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_windows-2.2.2.tar.gz",
-        "sha256": "9cedfacee553a02b48977a5e1d74bf08a36cc5647eba56fb83e57da20552f443",
+        "url": "https://pub.dev/api/archives/record_windows-2.2.3.tar.gz",
+        "sha256": "e6884f91be4370f122111aca3c04291ae5fe6d8fd045f87afa967635a02dbbac",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_windows-2.2.2"
+        "dest": ".pub-cache/hosted/pub.dev/record_windows-2.2.3"
     },
     {
         "type": "inline",
-        "contents": "9cedfacee553a02b48977a5e1d74bf08a36cc5647eba56fb83e57da20552f443",
+        "contents": "e6884f91be4370f122111aca3c04291ae5fe6d8fd045f87afa967635a02dbbac",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_windows-2.2.2.sha256"
+        "dest-filename": "record_windows-2.2.3.sha256"
     },
     {
         "type": "git",
@@ -4171,16 +4213,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/riverpod-3.3.2.tar.gz",
-        "sha256": "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76",
+        "url": "https://pub.dev/api/archives/riverpod-3.4.2.tar.gz",
+        "sha256": "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/riverpod-3.3.2"
+        "dest": ".pub-cache/hosted/pub.dev/riverpod-3.4.2"
     },
     {
         "type": "inline",
-        "contents": "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76",
+        "contents": "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "riverpod-3.3.2.sha256"
+        "dest-filename": "riverpod-3.4.2.sha256"
     },
     {
         "type": "archive",
@@ -4563,30 +4605,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/source_gen-4.2.3.tar.gz",
-        "sha256": "ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02",
+        "url": "https://pub.dev/api/archives/source_gen-4.2.4.tar.gz",
+        "sha256": "a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/source_gen-4.2.3"
+        "dest": ".pub-cache/hosted/pub.dev/source_gen-4.2.4"
     },
     {
         "type": "inline",
-        "contents": "ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02",
+        "contents": "a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "source_gen-4.2.3.sha256"
+        "dest-filename": "source_gen-4.2.4.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/source_helper-1.3.12.tar.gz",
-        "sha256": "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae",
+        "url": "https://pub.dev/api/archives/source_helper-1.3.13.tar.gz",
+        "sha256": "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/source_helper-1.3.12"
+        "dest": ".pub-cache/hosted/pub.dev/source_helper-1.3.13"
     },
     {
         "type": "inline",
-        "contents": "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae",
+        "contents": "5e6f216fdf6376c9f3852381ae037499797a3385377d388b011dac98d303c67c",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "source_helper-1.3.12.sha256"
+        "dest-filename": "source_helper-1.3.13.sha256"
     },
     {
         "type": "archive",
@@ -5305,16 +5347,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vector_graphics_compiler-1.2.6.tar.gz",
-        "sha256": "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3",
+        "url": "https://pub.dev/api/archives/vector_graphics_compiler-1.3.0.tar.gz",
+        "sha256": "4dca4feb77dc3ec7f6e27e49c53241eb8217f55e4f9b12599a27f8903bca5682",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vector_graphics_compiler-1.2.6"
+        "dest": ".pub-cache/hosted/pub.dev/vector_graphics_compiler-1.3.0"
     },
     {
         "type": "inline",
-        "contents": "142a9146f447d15b10bdc00e21d5f4d83e5b32bb5f8f8f5a04c75311344923a3",
+        "contents": "4dca4feb77dc3ec7f6e27e49c53241eb8217f55e4f9b12599a27f8903bca5682",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vector_graphics_compiler-1.2.6.sha256"
+        "dest-filename": "vector_graphics_compiler-1.3.0.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `0.9.1073+4274` (upstream commit `b8d47e91ef3d`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30585851828](https://github.com/matthiasn/lotti/actions/runs/30585851828).
