### PR TITLE
chore: 1.0.0+4276

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 8f60e363d38961d476adc64aa3e0337af322558f
+        commit: bb23b10d75b0a882222fa3c09973c1120e9eaf6e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.0+4276` (upstream commit `bb23b10d75b0`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30695346750](https://github.com/matthiasn/lotti/actions/runs/30695346750).
