### PR TITLE
chore: 1.0.1+4278

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 55e953878fe53eb02567361c3ed563e7240c6d67
+        commit: 13dad24b6ab970cd7e66bd503858aa7c7c9e8986
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.1+4278` (upstream commit `13dad24b6ab9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30748122301](https://github.com/matthiasn/lotti/actions/runs/30748122301).
