### PR TITLE
chore: 1.0.1+4279

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 13dad24b6ab970cd7e66bd503858aa7c7c9e8986
+        commit: 2b54273c283efe79bc137067971916644fd54db7
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.1+4279` (upstream commit `2b54273c283e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30768835051](https://github.com/matthiasn/lotti/actions/runs/30768835051).
