### PR TITLE
chore: 1.0.1+4280

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2b54273c283efe79bc137067971916644fd54db7
+        commit: cc154b00a05fd0f7cfef23914566a4e3fd13a647
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.1+4280` (upstream commit `cc154b00a05f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30867372452](https://github.com/matthiasn/lotti/actions/runs/30867372452).
