### PR TITLE
chore: 1.0.2+4281

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: cc154b00a05fd0f7cfef23914566a4e3fd13a647
+        commit: 827f9819cc35db4a6790c30b5370f9e6a44eba82
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.2+4281` (upstream commit `827f9819cc35`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30921597196](https://github.com/matthiasn/lotti/actions/runs/30921597196).
