### PR TITLE
chore: 1.0.2+4282

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 827f9819cc35db4a6790c30b5370f9e6a44eba82
+        commit: 4feda80e21fd994141b3fca5bd57d367634b24f3
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.2+4282` (upstream commit `4feda80e21fd`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#30961193035](https://github.com/matthiasn/lotti/actions/runs/30961193035).
