### PR TITLE
chore: 1.0.2+4283

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 4feda80e21fd994141b3fca5bd57d367634b24f3
+        commit: 0116ed60d9c2baf2411d70f4e3d4d24191a9ce8f
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -352,16 +352,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/build_daemon-4.1.3.tar.gz",
-        "sha256": "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712",
+        "url": "https://pub.dev/api/archives/build_daemon-4.1.4.tar.gz",
+        "sha256": "57c62a6d85c39d2a8c984e3b73b29bf2775a865e690309405aeade647fb2184c",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/build_daemon-4.1.3"
+        "dest": ".pub-cache/hosted/pub.dev/build_daemon-4.1.4"
     },
     {
         "type": "inline",
-        "contents": "8c0535c3b2f625619f4dd1036ef1127f2e77bfedf89ed2eb2676ef076e0b6712",
+        "contents": "57c62a6d85c39d2a8c984e3b73b29bf2775a865e690309405aeade647fb2184c",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "build_daemon-4.1.3.sha256"
+        "dest-filename": "build_daemon-4.1.4.sha256"
     },
     {
         "type": "archive",
@@ -394,16 +394,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/built_value-8.12.6.tar.gz",
-        "sha256": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
+        "url": "https://pub.dev/api/archives/built_value-8.12.7.tar.gz",
+        "sha256": "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/built_value-8.12.6"
+        "dest": ".pub-cache/hosted/pub.dev/built_value-8.12.7"
     },
     {
         "type": "inline",
-        "contents": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
+        "contents": "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "built_value-8.12.6.sha256"
+        "dest-filename": "built_value-8.12.7.sha256"
     },
     {
         "type": "archive",
@@ -1904,16 +1904,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_secure_storage_platform_interface-2.0.2.tar.gz",
-        "sha256": "06686df417f34fe9f963ed217b7fdce250e2f637ddd6c374d7eb054549770633",
+        "url": "https://pub.dev/api/archives/flutter_secure_storage_platform_interface-2.0.3.tar.gz",
+        "sha256": "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_platform_interface-2.0.2"
+        "dest": ".pub-cache/hosted/pub.dev/flutter_secure_storage_platform_interface-2.0.3"
     },
     {
         "type": "inline",
-        "contents": "06686df417f34fe9f963ed217b7fdce250e2f637ddd6c374d7eb054549770633",
+        "contents": "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_secure_storage_platform_interface-2.0.2.sha256"
+        "dest-filename": "flutter_secure_storage_platform_interface-2.0.3.sha256"
     },
     {
         "type": "archive",
@@ -2198,16 +2198,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/google_fonts-8.2.0.tar.gz",
-        "sha256": "d3f251381df389f7418d4dff416bd27c0a23138df22969aafd28c4a4b1bb3cd6",
+        "url": "https://pub.dev/api/archives/google_fonts-8.2.1.tar.gz",
+        "sha256": "e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/google_fonts-8.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/google_fonts-8.2.1"
     },
     {
         "type": "inline",
-        "contents": "d3f251381df389f7418d4dff416bd27c0a23138df22969aafd28c4a4b1bb3cd6",
+        "contents": "e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "google_fonts-8.2.0.sha256"
+        "dest-filename": "google_fonts-8.2.1.sha256"
     },
     {
         "type": "archive",
@@ -2870,16 +2870,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/listen-1.0.0-beta.4.tar.gz",
-        "sha256": "cb0ad74d7453d8f83a7c1fae401828681ef5df21d41a3a26a04af590c985d085",
+        "url": "https://pub.dev/api/archives/listen-1.0.1.tar.gz",
+        "sha256": "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/listen-1.0.0-beta.4"
+        "dest": ".pub-cache/hosted/pub.dev/listen-1.0.1"
     },
     {
         "type": "inline",
-        "contents": "cb0ad74d7453d8f83a7c1fae401828681ef5df21d41a3a26a04af590c985d085",
+        "contents": "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "listen-1.0.0-beta.4.sha256"
+        "dest-filename": "listen-1.0.1.sha256"
     },
     {
         "type": "archive",
@@ -3500,58 +3500,58 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_apple-9.4.10.tar.gz",
-        "sha256": "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420",
+        "url": "https://pub.dev/api/archives/permission_handler_apple-9.5.0.tar.gz",
+        "sha256": "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.4.10"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.5.0"
     },
     {
         "type": "inline",
-        "contents": "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420",
+        "contents": "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_apple-9.4.10.sha256"
+        "dest-filename": "permission_handler_apple-9.5.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_html-0.1.3+5.tar.gz",
-        "sha256": "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24",
+        "url": "https://pub.dev/api/archives/permission_handler_html-0.1.4+1.tar.gz",
+        "sha256": "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_html-0.1.3+5"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_html-0.1.4+1"
     },
     {
         "type": "inline",
-        "contents": "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24",
+        "contents": "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_html-0.1.3+5.sha256"
+        "dest-filename": "permission_handler_html-0.1.4+1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_platform_interface-4.3.0.tar.gz",
-        "sha256": "eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878",
+        "url": "https://pub.dev/api/archives/permission_handler_platform_interface-4.4.0.tar.gz",
+        "sha256": "a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_platform_interface-4.3.0"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_platform_interface-4.4.0"
     },
     {
         "type": "inline",
-        "contents": "eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878",
+        "contents": "a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_platform_interface-4.3.0.sha256"
+        "dest-filename": "permission_handler_platform_interface-4.4.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_windows-0.2.1.tar.gz",
-        "sha256": "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e",
+        "url": "https://pub.dev/api/archives/permission_handler_windows-0.2.2.tar.gz",
+        "sha256": "caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_windows-0.2.1"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_windows-0.2.2"
     },
     {
         "type": "inline",
-        "contents": "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e",
+        "contents": "caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_windows-0.2.1.sha256"
+        "dest-filename": "permission_handler_windows-0.2.2.sha256"
     },
     {
         "type": "archive",
@@ -5235,16 +5235,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vector_graphics-1.2.2.tar.gz",
-        "sha256": "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d",
+        "url": "https://pub.dev/api/archives/vector_graphics-1.2.3.tar.gz",
+        "sha256": "9d0e3b9cb16542ad660daee871e726a10d13a93b7b5391677c3160e8f5e83935",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vector_graphics-1.2.2"
+        "dest": ".pub-cache/hosted/pub.dev/vector_graphics-1.2.3"
     },
     {
         "type": "inline",
-        "contents": "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d",
+        "contents": "9d0e3b9cb16542ad660daee871e726a10d13a93b7b5391677c3160e8f5e83935",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vector_graphics-1.2.2.sha256"
+        "dest-filename": "vector_graphics-1.2.3.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `1.0.2+4283` (upstream commit `0116ed60d9c2`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31003526987](https://github.com/matthiasn/lotti/actions/runs/31003526987).
