### PR TITLE
chore: 1.0.3+4284

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 0116ed60d9c2baf2411d70f4e3d4d24191a9ce8f
+        commit: 0d164089c9852fa9d9ca858494e4a7f3c8d105d6
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.3+4284` (upstream commit `0d164089c985`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31026144265](https://github.com/matthiasn/lotti/actions/runs/31026144265).
