### PR TITLE
chore: 1.0.4+4285

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 0d164089c9852fa9d9ca858494e4a7f3c8d105d6
+        commit: 946071bc1c9c49d8414a54ad730b2032af4a56b1
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.4+4285` (upstream commit `946071bc1c9c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31053764162](https://github.com/matthiasn/lotti/actions/runs/31053764162).
