### PR TITLE
chore: 1.0.4+4286

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 946071bc1c9c49d8414a54ad730b2032af4a56b1
+        commit: 65dc953b218b242ee97ae759d75d850c9566d912
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.4+4286` (upstream commit `65dc953b218b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31057863511](https://github.com/matthiasn/lotti/actions/runs/31057863511).
