### PR TITLE
chore: 1.0.4+4287

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 65dc953b218b242ee97ae759d75d850c9566d912
+        commit: bb8af013c6a53c304d6bf5ece2bf1f836fd8ac8b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.4+4287` (upstream commit `bb8af013c6a5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31060281443](https://github.com/matthiasn/lotti/actions/runs/31060281443).
