### PR TITLE
chore: 1.0.4+4288

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: bb8af013c6a53c304d6bf5ece2bf1f836fd8ac8b
+        commit: fa8788f09ca2526490308431c3ceab5ec5a6b541
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.4+4288` (upstream commit `fa8788f09ca2`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31099957491](https://github.com/matthiasn/lotti/actions/runs/31099957491).
