### PR TITLE
chore: 1.0.4+4290

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: fa8788f09ca2526490308431c3ceab5ec5a6b541
+        commit: a7e8f1cef21ce581733c8d86d60d6fb308e725ff
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.4+4290` (upstream commit `a7e8f1cef21c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31109209640](https://github.com/matthiasn/lotti/actions/runs/31109209640).
