### PR TITLE
chore: 1.0.6+4299

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 31be5d034cdb38c747ad08dc3fc303cabb3229b4
+        commit: 2b23472f357b38a655c7dcc87566720b3d5876df
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.6+4299` (upstream commit `2b23472f357b`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31333914398](https://github.com/matthiasn/lotti/actions/runs/31333914398).
