### PR TITLE
chore: 1.0.6+4300

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 31be5d034cdb38c747ad08dc3fc303cabb3229b4
+        commit: 861715397be9c98bcecdc02e2116601886b9080d
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.6+4300` (upstream commit `861715397be9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31334617014](https://github.com/matthiasn/lotti/actions/runs/31334617014).
