### PR TITLE
chore: 1.0.7+4304

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 4a1e73b2373bfa656e83fffca459ce786b0215cf
+        commit: c4f69afab8244ea47286241a3f80551bdbde0d49
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.7+4304` (upstream commit `c4f69afab824`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31617922616](https://github.com/matthiasn/lotti/actions/runs/31617922616).
