### PR TITLE
chore: 1.0.8+4307

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 75d2ac6970914d632bb5d87b627c3c590312c4a0
+        commit: 1caeaa85d27707691698b26c729102d5cce77bc6
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.8+4307` (upstream commit `1caeaa85d277`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31644602103](https://github.com/matthiasn/lotti/actions/runs/31644602103).
