### PR TITLE
chore: 1.0.8+4309

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 1caeaa85d27707691698b26c729102d5cce77bc6
+        commit: cba59ab3a85a2287623cd9dd6f35c18af096f39f
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh
@@ -143,4 +143,4 @@ modules:
       - generated/sources/pubspec.json
     modules:
       - generated/modules/rustup-1.91.1.json
-      - generated/modules/flutter-sdk-3.44.8.json
+      - generated/modules/flutter-sdk-3.47.0.json

--- a/generated/modules/flutter-sdk-3.47.0.json
+++ b/generated/modules/flutter-sdk-3.47.0.json
@@ -1,0 +1,176 @@
+{
+    "name": "flutter",
+    "buildsystem": "simple",
+    "build-commands": [
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine-dart-sdk.stamp",
+        "cp flutter/bin/internal/material_fonts.version flutter/bin/cache/material_fonts.stamp",
+        "cp flutter/bin/internal/gradle_wrapper.version flutter/bin/cache/gradle_wrapper.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine_stamp.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/flutter_sdk.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/font-subset.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/linux-sdk.stamp",
+        "mkdir -p /var/lib && cp -r flutter /var/lib"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/flutter/flutter.git",
+            "tag": "3.47.0",
+            "commit": "4cf24164269a5ebf0c16a028a00727d0e77bbb05",
+            "dest": "flutter"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/dart-sdk-linux-x64.zip",
+            "sha256": "f323b0609e877508047fdc0c4a9188557c89d38faf68b85596a285d5ac6144f1",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/dart-sdk-linux-arm64.zip",
+            "sha256": "d4fd5a3b84435073018be7175a31abffbaf6317a082981d7639350bcc4ea8f73",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3012db47f3130e62f7cc0beabff968a33cbec8d8/fonts.zip",
+            "sha256": "e56fa8e9bb4589fde964be3de451f3e5b251e4a1eafb1dc98d94add034dd5a86",
+            "dest": "flutter/bin/cache/artifacts/material_fonts"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz",
+            "sha256": "31e9428baf1a2b2f485f1110c5899f852649b33d46a2e9b07f9d17752d50190a",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/gradle_wrapper"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/sky_engine.zip",
+            "sha256": "5fb9ad327dd8dd98cc081c9ee29fdb8cb85b14ae6d4d591ea0efff69c9971c56",
+            "dest": "flutter/bin/cache/pkg/sky_engine"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/flutter_gpu.zip",
+            "sha256": "5b86217ca3711db3047d9857c2831f9ff3970b1c689a1ed80a13e1be7e7be46a",
+            "dest": "flutter/bin/cache/pkg/flutter_gpu"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/flutter_patched_sdk.zip",
+            "sha256": "296be9f475ceb661e2255ef533ff52b18653ec5a21991d285d281014bcd34beb",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/flutter_patched_sdk_product.zip",
+            "sha256": "42c175c1cf0bf4ec45349449733a67e502e84b2510809d2b3d7310f0efd4c842",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk_product"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-x64/artifacts.zip",
+            "sha256": "df5f29cf9270aa5c8b9c52f1ce2510a70c5ce59288e824321ac7736d7927409f",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-x64/font-subset.zip",
+            "sha256": "dc11c53a8733147b3fd060f365304ca03a5c76cccf5f97be63c1591d1b2b5493",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-x64-profile/linux-x64-flutter-gtk.zip",
+            "sha256": "be78f0fb638e9590a461329f1d4ca1f60ff45ea6d72ec07c371d6abefad2dcae",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-x64-release/linux-x64-flutter-gtk.zip",
+            "sha256": "05abc9242e1940c6cc09871c7fdd07760c848ca51d25190ce146089169414b87",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-release"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-arm64/artifacts.zip",
+            "sha256": "e97abdb03465409bccf22be7c888b34e810b89b38e11ecb38a1a505f857e4493",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-arm64/font-subset.zip",
+            "sha256": "e689e690232c0c619a8e8d1238fa6d09769404481406f3e6537f01c5fc917088",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-arm64-profile/linux-arm64-flutter-gtk.zip",
+            "sha256": "b127eda3a8a4a6e4242bf1feb915746c9cd87da4b23431cfaab89120b2a73f77",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/linux-arm64-release/linux-arm64-flutter-gtk.zip",
+            "sha256": "fe64d92530942a4576773297635e86b4ca569113d7da52b3468a32992f1896c4",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-release"
+        },
+        {
+            "type": "patch",
+            "path": "../patches/flutter/shared.sh.patch"
+        },
+        {
+            "type": "script",
+            "dest": "flutter/bin",
+            "dest-filename": "setup-flutter.sh",
+            "commands": [
+                "flutter pub get --offline $@"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5f77625673248ee5846fbcaf5d3e1a3878386fd7/engine_stamp.json",
+            "sha256": "3d9462902a980bebc8b0956eb56ce1b6181013cad1f51c4d8e713561bf1eb937",
+            "dest": "flutter/bin/cache"
+        }
+    ]
+}

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -2030,16 +2030,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/formz-0.8.0.tar.gz",
-        "sha256": "382c7be452ff76833f9efa0b2333fec3a576393f6d2c7801725bed502f3d40c3",
+        "url": "https://pub.dev/api/archives/formz-0.8.1.tar.gz",
+        "sha256": "e8dc647e0d5922bcd7cbfd95ec3a320d8a9015b0902c7c8e69eaafb753041ce7",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/formz-0.8.0"
+        "dest": ".pub-cache/hosted/pub.dev/formz-0.8.1"
     },
     {
         "type": "inline",
-        "contents": "382c7be452ff76833f9efa0b2333fec3a576393f6d2c7801725bed502f3d40c3",
+        "contents": "e8dc647e0d5922bcd7cbfd95ec3a320d8a9015b0902c7c8e69eaafb753041ce7",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "formz-0.8.0.sha256"
+        "dest-filename": "formz-0.8.1.sha256"
     },
     {
         "type": "archive",
@@ -2268,16 +2268,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hooks-2.0.2.tar.gz",
-        "sha256": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
+        "url": "https://pub.dev/api/archives/hooks-2.1.0.tar.gz",
+        "sha256": "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hooks-2.0.2"
+        "dest": ".pub-cache/hosted/pub.dev/hooks-2.1.0"
     },
     {
         "type": "inline",
-        "contents": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
+        "contents": "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hooks-2.0.2.sha256"
+        "dest-filename": "hooks-2.1.0.sha256"
     },
     {
         "type": "archive",
@@ -2982,16 +2982,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matcher-0.12.19.tar.gz",
-        "sha256": "dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861",
+        "url": "https://pub.dev/api/archives/matcher-0.12.20.tar.gz",
+        "sha256": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matcher-0.12.19"
+        "dest": ".pub-cache/hosted/pub.dev/matcher-0.12.20"
     },
     {
         "type": "inline",
-        "contents": "dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861",
+        "contents": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matcher-0.12.19.sha256"
+        "dest-filename": "matcher-0.12.20.sha256"
     },
     {
         "type": "archive",
@@ -3010,16 +3010,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matrix-10.0.0.tar.gz",
-        "sha256": "9449c98ba2f8d5b72404ed41a03f3cb9942f691f2029b42b10f7fb86a570adfd",
+        "url": "https://pub.dev/api/archives/matrix-10.0.1.tar.gz",
+        "sha256": "3d6c6b6dabbcca8e16a4ebfb19baddcd54a15654909d4b6a39fbc657f6727d01",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matrix-10.0.0"
+        "dest": ".pub-cache/hosted/pub.dev/matrix-10.0.1"
     },
     {
         "type": "inline",
-        "contents": "9449c98ba2f8d5b72404ed41a03f3cb9942f691f2029b42b10f7fb86a570adfd",
+        "contents": "3d6c6b6dabbcca8e16a4ebfb19baddcd54a15654909d4b6a39fbc657f6727d01",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matrix-10.0.0.sha256"
+        "dest-filename": "matrix-10.0.1.sha256"
     },
     {
         "type": "archive",
@@ -3122,16 +3122,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/meta-1.18.0.tar.gz",
-        "sha256": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
+        "url": "https://pub.dev/api/archives/meta-1.19.0.tar.gz",
+        "sha256": "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/meta-1.18.0"
+        "dest": ".pub-cache/hosted/pub.dev/meta-1.19.0"
     },
     {
         "type": "inline",
-        "contents": "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349",
+        "contents": "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "meta-1.18.0.sha256"
+        "dest-filename": "meta-1.19.0.sha256"
     },
     {
         "type": "archive",
@@ -3234,16 +3234,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/native_toolchain_c-0.19.2.tar.gz",
-        "sha256": "f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72",
+        "url": "https://pub.dev/api/archives/native_toolchain_c-0.19.3.tar.gz",
+        "sha256": "a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/native_toolchain_c-0.19.2"
+        "dest": ".pub-cache/hosted/pub.dev/native_toolchain_c-0.19.3"
     },
     {
         "type": "inline",
-        "contents": "f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72",
+        "contents": "a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "native_toolchain_c-0.19.2.sha256"
+        "dest-filename": "native_toolchain_c-0.19.3.sha256"
     },
     {
         "type": "archive",
@@ -3542,16 +3542,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/permission_handler_apple-9.5.0.tar.gz",
-        "sha256": "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b",
+        "url": "https://pub.dev/api/archives/permission_handler_apple-9.6.1.tar.gz",
+        "sha256": "f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.5.0"
+        "dest": ".pub-cache/hosted/pub.dev/permission_handler_apple-9.6.1"
     },
     {
         "type": "inline",
-        "contents": "11b7e94a9d2fbee23c27f0cae0105c6266c03fd83b9a2eda6cf09141fc82624b",
+        "contents": "f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "permission_handler_apple-9.5.0.sha256"
+        "dest-filename": "permission_handler_apple-9.6.1.sha256"
     },
     {
         "type": "archive",
@@ -4116,16 +4116,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_use-0.6.0.tar.gz",
-        "sha256": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
+        "url": "https://pub.dev/api/archives/record_use-1.1.0.tar.gz",
+        "sha256": "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_use-0.6.0"
+        "dest": ".pub-cache/hosted/pub.dev/record_use-1.1.0"
     },
     {
         "type": "inline",
-        "contents": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
+        "contents": "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_use-0.6.0.sha256"
+        "dest-filename": "record_use-1.1.0.sha256"
     },
     {
         "type": "archive",
@@ -4983,44 +4983,44 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/test-1.31.0.tar.gz",
-        "sha256": "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20",
+        "url": "https://pub.dev/api/archives/test-1.31.1.tar.gz",
+        "sha256": "ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/test-1.31.0"
+        "dest": ".pub-cache/hosted/pub.dev/test-1.31.1"
     },
     {
         "type": "inline",
-        "contents": "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20",
+        "contents": "ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "test-1.31.0.sha256"
+        "dest-filename": "test-1.31.1.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/test_api-0.7.11.tar.gz",
-        "sha256": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
+        "url": "https://pub.dev/api/archives/test_api-0.7.12.tar.gz",
+        "sha256": "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/test_api-0.7.11"
+        "dest": ".pub-cache/hosted/pub.dev/test_api-0.7.12"
     },
     {
         "type": "inline",
-        "contents": "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e",
+        "contents": "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "test_api-0.7.11.sha256"
+        "dest-filename": "test_api-0.7.12.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/test_core-0.6.17.tar.gz",
-        "sha256": "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34",
+        "url": "https://pub.dev/api/archives/test_core-0.6.18.tar.gz",
+        "sha256": "d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/test_core-0.6.17"
+        "dest": ".pub-cache/hosted/pub.dev/test_core-0.6.18"
     },
     {
         "type": "inline",
-        "contents": "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34",
+        "contents": "d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "test_core-0.6.17.sha256"
+        "dest-filename": "test_core-0.6.18.sha256"
     },
     {
         "type": "archive",
@@ -5333,16 +5333,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vector_math-2.2.0.tar.gz",
-        "sha256": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+        "url": "https://pub.dev/api/archives/vector_math-2.4.2.tar.gz",
+        "sha256": "f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vector_math-2.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/vector_math-2.4.2"
     },
     {
         "type": "inline",
-        "contents": "d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b",
+        "contents": "f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vector_math-2.2.0.sha256"
+        "dest-filename": "vector_math-2.4.2.sha256"
     },
     {
         "type": "archive",
@@ -5361,16 +5361,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/video_player-2.13.0.tar.gz",
-        "sha256": "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d",
+        "url": "https://pub.dev/api/archives/video_player-2.14.0.tar.gz",
+        "sha256": "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/video_player-2.13.0"
+        "dest": ".pub-cache/hosted/pub.dev/video_player-2.14.0"
     },
     {
         "type": "inline",
-        "contents": "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d",
+        "contents": "8c837b570dccb9ae6ff73d2e0b03c7e708bfefd3bd1194faa7f3e7f200dfc399",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "video_player-2.13.0.sha256"
+        "dest-filename": "video_player-2.14.0.sha256"
     },
     {
         "type": "archive",
@@ -5809,30 +5809,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/built_value-8.12.5.tar.gz",
-        "sha256": "0730c18c770d05636a8f945c32a4d7d81cb6e0f0148c8db4ad12e7748f7e49af",
+        "url": "https://pub.dev/api/archives/built_value-8.12.6.tar.gz",
+        "sha256": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/built_value-8.12.5"
+        "dest": ".pub-cache/hosted/pub.dev/built_value-8.12.6"
     },
     {
         "type": "inline",
-        "contents": "0730c18c770d05636a8f945c32a4d7d81cb6e0f0148c8db4ad12e7748f7e49af",
+        "contents": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "built_value-8.12.5.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/code_assets-1.0.0.tar.gz",
-        "sha256": "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/code_assets-1.0.0"
-    },
-    {
-        "type": "inline",
-        "contents": "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "code_assets-1.0.0.sha256"
+        "dest-filename": "built_value-8.12.6.sha256"
     },
     {
         "type": "archive",
@@ -5865,20 +5851,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/coverage-1.15.0.tar.gz",
-        "sha256": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/coverage-1.15.0"
-    },
-    {
-        "type": "inline",
-        "contents": "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "coverage-1.15.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/dap-1.4.0.tar.gz",
         "sha256": "42b0b083a09c59a118741769e218fc3738980ab591114f09d1026241d2b9c290",
         "strip-components": 0,
@@ -5907,16 +5879,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/data_assets-0.19.6.tar.gz",
-        "sha256": "d8b93648a338f471e576e0ba05f6b5d63a4e0fa447ca839a500267421d9245ba",
+        "url": "https://pub.dev/api/archives/data_assets-0.20.0.tar.gz",
+        "sha256": "8bfdbf25ec8a0f4b5a3c993042c4ab9996ba354f0b03d40f4e360f3730d71cae",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/data_assets-0.19.6"
+        "dest": ".pub-cache/hosted/pub.dev/data_assets-0.20.0"
     },
     {
         "type": "inline",
-        "contents": "d8b93648a338f471e576e0ba05f6b5d63a4e0fa447ca839a500267421d9245ba",
+        "contents": "8bfdbf25ec8a0f4b5a3c993042c4ab9996ba354f0b03d40f4e360f3730d71cae",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "data_assets-0.19.6.sha256"
+        "dest-filename": "data_assets-0.20.0.sha256"
     },
     {
         "type": "archive",
@@ -5977,16 +5949,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/dwds-26.2.5.tar.gz",
-        "sha256": "37829d11cc9ef3fe4cd8c6263873b4e8b640a8862d4d741b8fa58dd1eeadfb48",
+        "url": "https://pub.dev/api/archives/dwds-27.1.2.tar.gz",
+        "sha256": "280ca49e939f3f8a96f3a77bb17dfc284fd92b5004bd144ccafb2ab3ddb3b7f9",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/dwds-26.2.5"
+        "dest": ".pub-cache/hosted/pub.dev/dwds-27.1.2"
     },
     {
         "type": "inline",
-        "contents": "37829d11cc9ef3fe4cd8c6263873b4e8b640a8862d4d741b8fa58dd1eeadfb48",
+        "contents": "280ca49e939f3f8a96f3a77bb17dfc284fd92b5004bd144ccafb2ab3ddb3b7f9",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "dwds-26.2.5.sha256"
+        "dest-filename": "dwds-27.1.2.sha256"
     },
     {
         "type": "archive",
@@ -6033,58 +6005,30 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hooks-1.0.2.tar.gz",
-        "sha256": "e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388",
+        "url": "https://pub.dev/api/archives/hooks-2.0.2.tar.gz",
+        "sha256": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hooks-1.0.2"
+        "dest": ".pub-cache/hosted/pub.dev/hooks-2.0.2"
     },
     {
         "type": "inline",
-        "contents": "e79ed1e8e1929bc6ecb6ec85f0cb519c887aa5b423705ded0d0f2d9226def388",
+        "contents": "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hooks-1.0.2.sha256"
+        "dest-filename": "hooks-2.0.2.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hooks_runner-1.1.1.tar.gz",
-        "sha256": "1da87338673b2c0618cd65ad07cebb6244f69e70e9ee0aad3288605eba1e18dc",
+        "url": "https://pub.dev/api/archives/hooks_runner-1.5.0.tar.gz",
+        "sha256": "a67ab8106545fcffcf5c43edf84b4be222fc95a9fbec8baef1bcaf4534540cfc",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hooks_runner-1.1.1"
+        "dest": ".pub-cache/hosted/pub.dev/hooks_runner-1.5.0"
     },
     {
         "type": "inline",
-        "contents": "1da87338673b2c0618cd65ad07cebb6244f69e70e9ee0aad3288605eba1e18dc",
+        "contents": "a67ab8106545fcffcf5c43edf84b4be222fc95a9fbec8baef1bcaf4534540cfc",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hooks_runner-1.1.1.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/intl-0.20.2.tar.gz",
-        "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/intl-0.20.2"
-    },
-    {
-        "type": "inline",
-        "contents": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "intl-0.20.2.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/json_annotation-4.11.0.tar.gz",
-        "sha256": "cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/json_annotation-4.11.0"
-    },
-    {
-        "type": "inline",
-        "contents": "cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "json_annotation-4.11.0.sha256"
+        "dest-filename": "hooks_runner-1.5.0.sha256"
     },
     {
         "type": "archive",
@@ -6103,30 +6047,44 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/multicast_dns-0.3.3.tar.gz",
-        "sha256": "de72ada5c3db6fdd6ad4ae99452fe05fb403c4bb37c67ceb255ddd37d2b5b1eb",
+        "url": "https://pub.dev/api/archives/meta-1.18.3.tar.gz",
+        "sha256": "c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/multicast_dns-0.3.3"
+        "dest": ".pub-cache/hosted/pub.dev/meta-1.18.3"
     },
     {
         "type": "inline",
-        "contents": "de72ada5c3db6fdd6ad4ae99452fe05fb403c4bb37c67ceb255ddd37d2b5b1eb",
+        "contents": "c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "multicast_dns-0.3.3.sha256"
+        "dest-filename": "meta-1.18.3.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/mustache_template-2.0.4.tar.gz",
-        "sha256": "544ff0b837836f5ad6b351e7a676ff7c2cad4fa412c465908aeb9358caddb6fc",
+        "url": "https://pub.dev/api/archives/multicast_dns-0.3.3+1.tar.gz",
+        "sha256": "134668a9605c747322d8c3eb0e89a4c0cbdedb29f8d2d5ae29d14daef724987b",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/mustache_template-2.0.4"
+        "dest": ".pub-cache/hosted/pub.dev/multicast_dns-0.3.3+1"
     },
     {
         "type": "inline",
-        "contents": "544ff0b837836f5ad6b351e7a676ff7c2cad4fa412c465908aeb9358caddb6fc",
+        "contents": "134668a9605c747322d8c3eb0e89a4c0cbdedb29f8d2d5ae29d14daef724987b",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "mustache_template-2.0.4.sha256"
+        "dest-filename": "multicast_dns-0.3.3+1.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/mustache_template-2.0.5.tar.gz",
+        "sha256": "c689b4d59176f8c7a2860aab765d205916aa5b06cfafff7613bfcc42fa996143",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/mustache_template-2.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "c689b4d59176f8c7a2860aab765d205916aa5b06cfafff7613bfcc42fa996143",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "mustache_template-2.0.5.sha256"
     },
     {
         "type": "archive",
@@ -6145,72 +6103,72 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/shelf_proxy-1.0.4.tar.gz",
-        "sha256": "a71d2307f4393211930c590c3d2c00630f6c5a7a77edc1ef6436dfd85a6a7ee3",
+        "url": "https://pub.dev/api/archives/record_use-0.6.0.tar.gz",
+        "sha256": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/shelf_proxy-1.0.4"
+        "dest": ".pub-cache/hosted/pub.dev/record_use-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "a71d2307f4393211930c590c3d2c00630f6c5a7a77edc1ef6436dfd85a6a7ee3",
+        "contents": "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "shelf_proxy-1.0.4.sha256"
+        "dest-filename": "record_use-0.6.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sse-4.1.8.tar.gz",
-        "sha256": "fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643",
+        "url": "https://pub.dev/api/archives/shelf_proxy-1.0.5.tar.gz",
+        "sha256": "0c3a7b2b4c111cae8a6d9077701e0622c6013d38a780373ac359d6d45b3aa10b",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sse-4.1.8"
+        "dest": ".pub-cache/hosted/pub.dev/shelf_proxy-1.0.5"
     },
     {
         "type": "inline",
-        "contents": "fcc97470240bb37377f298e2bd816f09fd7216c07928641c0560719f50603643",
+        "contents": "0c3a7b2b4c111cae8a6d9077701e0622c6013d38a780373ac359d6d45b3aa10b",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sse-4.1.8.sha256"
+        "dest-filename": "shelf_proxy-1.0.5.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/standard_message_codec-0.0.1+4.tar.gz",
-        "sha256": "fc7dd712d191b7e33196a0ecf354c4573492bb95995e7166cb6f73b047f9cae0",
+        "url": "https://pub.dev/api/archives/sse-4.2.0.tar.gz",
+        "sha256": "a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/standard_message_codec-0.0.1+4"
+        "dest": ".pub-cache/hosted/pub.dev/sse-4.2.0"
     },
     {
         "type": "inline",
-        "contents": "fc7dd712d191b7e33196a0ecf354c4573492bb95995e7166cb6f73b047f9cae0",
+        "contents": "a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "standard_message_codec-0.0.1+4.sha256"
+        "dest-filename": "sse-4.2.0.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/unified_analytics-8.0.14.tar.gz",
-        "sha256": "406724e9231f8e30119673133c1087f9b24e2a75ba7111ea071253d57bb8f3b9",
+        "url": "https://pub.dev/api/archives/standard_message_codec-0.0.1+5.tar.gz",
+        "sha256": "f10b3fbdb4d56c6bc4d160ef5b3d6346df7a998a84876d05886a75d17eb290e6",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/unified_analytics-8.0.14"
+        "dest": ".pub-cache/hosted/pub.dev/standard_message_codec-0.0.1+5"
     },
     {
         "type": "inline",
-        "contents": "406724e9231f8e30119673133c1087f9b24e2a75ba7111ea071253d57bb8f3b9",
+        "contents": "f10b3fbdb4d56c6bc4d160ef5b3d6346df7a998a84876d05886a75d17eb290e6",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "unified_analytics-8.0.14.sha256"
+        "dest-filename": "standard_message_codec-0.0.1+5.sha256"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/usage-4.1.1.tar.gz",
-        "sha256": "0bdbde65a6e710343d02a56552eeaefd20b735e04bfb6b3ee025b6b22e8d0e15",
+        "url": "https://pub.dev/api/archives/unified_analytics-8.0.15.tar.gz",
+        "sha256": "0988c50d794f3cd96f6df92b4b35b7c333bbf869df304fc6062a45ebc7eb0776",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/usage-4.1.1"
+        "dest": ".pub-cache/hosted/pub.dev/unified_analytics-8.0.15"
     },
     {
         "type": "inline",
-        "contents": "0bdbde65a6e710343d02a56552eeaefd20b735e04bfb6b3ee025b6b22e8d0e15",
+        "contents": "0988c50d794f3cd96f6df92b4b35b7c333bbf869df304fc6062a45ebc7eb0776",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "usage-4.1.1.sha256"
+        "dest-filename": "unified_analytics-8.0.15.sha256"
     },
     {
         "type": "archive",
@@ -6225,20 +6183,6 @@
         "contents": "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "uuid-4.5.3.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vm_service-15.0.2.tar.gz",
-        "sha256": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vm_service-15.0.2"
-    },
-    {
-        "type": "inline",
-        "contents": "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vm_service-15.0.2.sha256"
     },
     {
         "type": "archive",
@@ -6379,34 +6323,6 @@
         "contents": "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "lints-6.1.0.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matcher-0.12.20.tar.gz",
-        "sha256": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matcher-0.12.20"
-    },
-    {
-        "type": "inline",
-        "contents": "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matcher-0.12.20.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/meta-1.18.3.tar.gz",
-        "sha256": "c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/meta-1.18.3"
-    },
-    {
-        "type": "inline",
-        "contents": "c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "meta-1.18.3.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `1.0.8+4309` (upstream commit `cba59ab3a85a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31698397771](https://github.com/matthiasn/lotti/actions/runs/31698397771).
