### PR TITLE
chore: 1.0.9+4314

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 86fded736498d4fcfb5b561f169d4dfa31d20570
+        commit: 203f8ffb05cf750a1d037c47cf8d67984ba3aad2
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.9+4314` (upstream commit `203f8ffb05cf`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31740115291](https://github.com/matthiasn/lotti/actions/runs/31740115291).
