### PR TITLE
chore: 1.0.10+4315

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 203f8ffb05cf750a1d037c47cf8d67984ba3aad2
+        commit: 5edc9a9088178cbc2da3962be35b33d36dfcd99d
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4315` (upstream commit `5edc9a908817`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31745303718](https://github.com/matthiasn/lotti/actions/runs/31745303718).
