### PR TITLE
chore: 1.0.10+4317

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5edc9a9088178cbc2da3962be35b33d36dfcd99d
+        commit: ca7c8ac707073f1b9f8928ea7851607aeed5e182
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4317` (upstream commit `ca7c8ac70707`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31752402205](https://github.com/matthiasn/lotti/actions/runs/31752402205).
