### PR TITLE
chore: 1.0.10+4319

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 239d97f2252c7f6f4f7d7349f0e801b30a32c9d5
+        commit: 84f112f4efaffaeaf21baf006d737a388914c0c0
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4319` (upstream commit `84f112f4efaf`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31782970864](https://github.com/matthiasn/lotti/actions/runs/31782970864).
