### PR TITLE
chore: 1.0.10+4320

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 239d97f2252c7f6f4f7d7349f0e801b30a32c9d5
+        commit: 5273bee88e3ccd96304338a67b261ae0a5c6dbfe
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4320` (upstream commit `5273bee88e3c`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31798331590](https://github.com/matthiasn/lotti/actions/runs/31798331590).
