### PR TITLE
chore: 1.0.10+4324

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 239d97f2252c7f6f4f7d7349f0e801b30a32c9d5
+        commit: e9a3069c829743a3ef2bc7fc6c4e0ce7f12704a5
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4324` (upstream commit `e9a3069c8297`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31903418445](https://github.com/matthiasn/lotti/actions/runs/31903418445).
