### PR TITLE
chore: 1.0.10+4325

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e9a3069c829743a3ef2bc7fc6c4e0ce7f12704a5
+        commit: 9b6127211575d179d9c010ffee70b8ef27c79858
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4325` (upstream commit `9b6127211575`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31905835301](https://github.com/matthiasn/lotti/actions/runs/31905835301).
