### PR TITLE
chore: 1.0.10+4326

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e9a3069c829743a3ef2bc7fc6c4e0ce7f12704a5
+        commit: f0393ae085d0fd2586dc39d1a3c8bcb697d0f855
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4326` (upstream commit `f0393ae085d0`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31945720090](https://github.com/matthiasn/lotti/actions/runs/31945720090).
