### PR TITLE
chore: 1.0.10+4327

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e9a3069c829743a3ef2bc7fc6c4e0ce7f12704a5
+        commit: 31dce330455623b82214951972443b809f018a8e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4327` (upstream commit `31dce3304556`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31951053947](https://github.com/matthiasn/lotti/actions/runs/31951053947).
