### PR TITLE
chore: 1.0.10+4328

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: e9a3069c829743a3ef2bc7fc6c4e0ce7f12704a5
+        commit: c5f23887090a4d2e8674262ef57c7b8077bb9837
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.10+4328` (upstream commit `c5f23887090a`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31963046488](https://github.com/matthiasn/lotti/actions/runs/31963046488).
