### PR TITLE
chore: 1.0.11+4330

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 31dce330455623b82214951972443b809f018a8e
+        commit: dfaea502674e77b959b92af7211204a1c7580484
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4330` (upstream commit `dfaea502674e`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31974332699](https://github.com/matthiasn/lotti/actions/runs/31974332699).
