### PR TITLE
chore: 1.0.11+4331

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 31dce330455623b82214951972443b809f018a8e
+        commit: c74a5cb0bd734beb1c2eb5f8944eba0298ef3c36
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4331` (upstream commit `c74a5cb0bd73`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#31975382269](https://github.com/matthiasn/lotti/actions/runs/31975382269).
