### PR TITLE
chore: 1.0.11+4332

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: c74a5cb0bd734beb1c2eb5f8944eba0298ef3c36
+        commit: 38f6819bf178acf24c70299bc5f192a1e8097030
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4332` (upstream commit `38f6819bf178`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32023082044](https://github.com/matthiasn/lotti/actions/runs/32023082044).
