### PR TITLE
chore: 1.0.11+4333

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 38f6819bf178acf24c70299bc5f192a1e8097030
+        commit: fc5911334248616e15f4da90f7d9511a5b37ea4e
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4333` (upstream commit `fc5911334248`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32174701218](https://github.com/matthiasn/lotti/actions/runs/32174701218).
