### PR TITLE
chore: 1.0.11+4336

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: fc5911334248616e15f4da90f7d9511a5b37ea4e
+        commit: 5eae6384b9a5dc59b555f739e5586cd22e113f65
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -1401,6 +1401,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/flutter_contacts-2.3.1.tar.gz",
+        "sha256": "3a018a04ffc88f8555068f86b7750c7cbc758e9ebccafa985f91353bcb6df496",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/flutter_contacts-2.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "3a018a04ffc88f8555068f86b7750c7cbc758e9ebccafa985f91353bcb6df496",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "flutter_contacts-2.3.1.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/flutter_dotenv-6.0.1.tar.gz",
         "sha256": "d41da11fb497314fbf89811ec30af02d1d898b47980a129f0a8c0a1720460ba2",
         "strip-components": 0,


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4336` (upstream commit `5eae6384b9a5`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32192546255](https://github.com/matthiasn/lotti/actions/runs/32192546255).
