### PR TITLE
chore: 1.0.11+4338

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 5eae6384b9a5dc59b555f739e5586cd22e113f65
+        commit: f7e4054d459f9a495e55a39a2078c962dc094a6c
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -1736,20 +1736,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/flutter_material_design_icons-3.1.0+7447.tar.gz",
-        "sha256": "9a7b6308736e328f9ce2249c3727a56a289c915a65ebf1b1b5f237c8232e92b7",
-        "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/flutter_material_design_icons-3.1.0+7447"
-    },
-    {
-        "type": "inline",
-        "contents": "9a7b6308736e328f9ce2249c3727a56a289c915a65ebf1b1b5f237c8232e92b7",
-        "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "flutter_material_design_icons-3.1.0+7447.sha256"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/flutter_math_fork-0.7.4.tar.gz",
         "sha256": "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407",
         "strip-components": 0,
@@ -2978,6 +2964,20 @@
         "contents": "c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "logging-1.3.0.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/lucide_icons_flutter-3.1.15.tar.gz",
+        "sha256": "234155b10641b8ef7bab8a077b93ea6c92fe849c06740cf89dcd86dcf350934f",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/lucide_icons_flutter-3.1.15"
+    },
+    {
+        "type": "inline",
+        "contents": "234155b10641b8ef7bab8a077b93ea6c92fe849c06740cf89dcd86dcf350934f",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "lucide_icons_flutter-3.1.15.sha256"
     },
     {
         "type": "archive",


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4338` (upstream commit `f7e4054d459f`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32299609648](https://github.com/matthiasn/lotti/actions/runs/32299609648).
