### PR TITLE
chore: 1.0.11+4340

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f7e4054d459f9a495e55a39a2078c962dc094a6c
+        commit: 23f2651d5610fb3552ab674c04134c4e90ff8237
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4340` (upstream commit `23f2651d5610`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32313136293](https://github.com/matthiasn/lotti/actions/runs/32313136293).
