### PR TITLE
chore: 1.0.11+4341

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: f7e4054d459f9a495e55a39a2078c962dc094a6c
+        commit: 2381f54809e9f4858f7d84668392ac5bf10962b4
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4341` (upstream commit `2381f54809e9`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32355990673](https://github.com/matthiasn/lotti/actions/runs/32355990673).
