### PR TITLE
chore: 1.0.11+4344

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: 2381f54809e9f4858f7d84668392ac5bf10962b4
+        commit: a736cacff282e99745c38d15473342ca7fce1087
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh
@@ -143,4 +143,4 @@ modules:
       - generated/sources/pubspec.json
     modules:
       - generated/modules/rustup-1.91.1.json
-      - generated/modules/flutter-sdk-3.47.0.json
+      - generated/modules/flutter-sdk-3.47.1.json

--- a/generated/modules/flutter-sdk-3.47.1.json
+++ b/generated/modules/flutter-sdk-3.47.1.json
@@ -1,0 +1,176 @@
+{
+    "name": "flutter",
+    "buildsystem": "simple",
+    "build-commands": [
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine-dart-sdk.stamp",
+        "cp flutter/bin/internal/material_fonts.version flutter/bin/cache/material_fonts.stamp",
+        "cp flutter/bin/internal/gradle_wrapper.version flutter/bin/cache/gradle_wrapper.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/engine_stamp.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/flutter_sdk.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/font-subset.stamp",
+        "cp flutter/bin/internal/engine.version flutter/bin/cache/linux-sdk.stamp",
+        "mkdir -p /var/lib && cp -r flutter /var/lib"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/flutter/flutter.git",
+            "tag": "3.47.1",
+            "commit": "6655482ec06e547f90abf8ae7590466f4415978d",
+            "dest": "flutter"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/dart-sdk-linux-x64.zip",
+            "sha256": "c97a1543697c4363d0d4413279b1db780951d08c7f1fabce77fd1ff29630769e",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/dart-sdk-linux-arm64.zip",
+            "sha256": "c8468da962c164e0519192eacecc7cc245d640bbab7d1e39777b853766e627c1",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3012db47f3130e62f7cc0beabff968a33cbec8d8/fonts.zip",
+            "sha256": "e56fa8e9bb4589fde964be3de451f3e5b251e4a1eafb1dc98d94add034dd5a86",
+            "dest": "flutter/bin/cache/artifacts/material_fonts"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/gradle-wrapper/fd5c1f2c013565a3bea56ada6df9d2b8e96d56aa/gradle-wrapper.tgz",
+            "sha256": "31e9428baf1a2b2f485f1110c5899f852649b33d46a2e9b07f9d17752d50190a",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/gradle_wrapper"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/sky_engine.zip",
+            "sha256": "cba21df7f1a5541353607c4cef3d88ac8a757f2766e81b1730a8bff5fbd10f96",
+            "dest": "flutter/bin/cache/pkg/sky_engine"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/flutter_gpu.zip",
+            "sha256": "4265054906350fa74b58563c792dfd4742583fe9f5d06f1aa6edeaa3b80420ef",
+            "dest": "flutter/bin/cache/pkg/flutter_gpu"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/flutter_patched_sdk.zip",
+            "sha256": "6d863ed7a8d247b7245236ec2329b70c8aaf673a58e735e2b8e3f0a5c5cdf9ba",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk"
+        },
+        {
+            "type": "archive",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/flutter_patched_sdk_product.zip",
+            "sha256": "a068b67fd698b2d55243cf5363177fe749fd73d735f9aea424f06f66349cbf95",
+            "dest": "flutter/bin/cache/artifacts/engine/common/flutter_patched_sdk_product"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-x64/artifacts.zip",
+            "sha256": "6560098e9cc870ef7de8c23f7ac6ae43a5342342b733f8e1169962e849ee181a",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-x64/font-subset.zip",
+            "sha256": "0680e9261318e9b917561e31252707625a5d41c384a2793e567fceeb327d9691",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-x64-profile/linux-x64-flutter-gtk.zip",
+            "sha256": "6cfdbaa9fa7d27264f067d6d1ac4e9aa3f59d01820ca3f16cca08545c0548f59",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "x86_64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-x64-release/linux-x64-flutter-gtk.zip",
+            "sha256": "ff8b91901a81d2e32dfab2dd08d64600f11689a54664942e549486b43a043b6b",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-x64-release"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-arm64/artifacts.zip",
+            "sha256": "766e1a93afd0027ccffd95e9bd35c083f4de00e4fde80028f98e7ed58838c1f4",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-arm64/font-subset.zip",
+            "sha256": "815fb4a835986431f86ab8562ee8b4f7b125cca164e9801e06d92b42da57f49a",
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-arm64-profile/linux-arm64-flutter-gtk.zip",
+            "sha256": "795cbdfbc50b5e963dcbf9adb2fdf0b458dc6ce5b5796aa3cb8cc9277f0b7f52",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-profile"
+        },
+        {
+            "type": "archive",
+            "only-arches": [
+                "aarch64"
+            ],
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/linux-arm64-release/linux-arm64-flutter-gtk.zip",
+            "sha256": "e2cb0cd315fa25e011a7d981ffc1c6c74161d144cc75b9e2eb6ba0b12a3fb8cb",
+            "strip-components": 0,
+            "dest": "flutter/bin/cache/artifacts/engine/linux-arm64-release"
+        },
+        {
+            "type": "patch",
+            "path": "../patches/flutter/shared.sh.patch"
+        },
+        {
+            "type": "script",
+            "dest": "flutter/bin",
+            "dest-filename": "setup-flutter.sh",
+            "commands": [
+                "flutter pub get --offline $@"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://storage.googleapis.com/flutter_infra_release/flutter/5d531788691ec3404cac0cee66ead4007b177363/engine_stamp.json",
+            "sha256": "6477a5e16de890334290676ea7c9391f6008cc1d6efd4eccf8c8839e7c2ce137",
+            "dest": "flutter/bin/cache"
+        }
+    ]
+}

--- a/generated/sources/pubspec.json
+++ b/generated/sources/pubspec.json
@@ -86,16 +86,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/archive-4.0.9.tar.gz",
-        "sha256": "a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff",
+        "url": "https://pub.dev/api/archives/archive-4.1.0.tar.gz",
+        "sha256": "be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/archive-4.0.9"
+        "dest": ".pub-cache/hosted/pub.dev/archive-4.1.0"
     },
     {
         "type": "inline",
-        "contents": "a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff",
+        "contents": "be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "archive-4.0.9.sha256"
+        "dest-filename": "archive-4.1.0.sha256"
     },
     {
         "type": "archive",
@@ -590,16 +590,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/code_assets-1.2.1.tar.gz",
-        "sha256": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
+        "url": "https://pub.dev/api/archives/code_assets-2.0.0.tar.gz",
+        "sha256": "cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/code_assets-1.2.1"
+        "dest": ".pub-cache/hosted/pub.dev/code_assets-2.0.0"
     },
     {
         "type": "inline",
-        "contents": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
+        "contents": "cfd4f5f575a49c5f10ca856e9846073f1e6c3ee94912377eea5f6cefc5272941",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "code_assets-1.2.1.sha256"
+        "dest-filename": "code_assets-2.0.0.sha256"
     },
     {
         "type": "archive",
@@ -856,16 +856,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/dbus-0.7.14.tar.gz",
-        "sha256": "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645",
+        "url": "https://pub.dev/api/archives/dbus-0.7.15.tar.gz",
+        "sha256": "a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/dbus-0.7.14"
+        "dest": ".pub-cache/hosted/pub.dev/dbus-0.7.15"
     },
     {
         "type": "inline",
-        "contents": "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645",
+        "contents": "a48d5da28e89bd02196e80d81ed8d7954923d00a0f4a68cc20b575038f023383",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "dbus-0.7.14.sha256"
+        "dest-filename": "dbus-0.7.15.sha256"
     },
     {
         "type": "archive",
@@ -2268,16 +2268,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/hooks-2.1.0.tar.gz",
-        "sha256": "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4",
+        "url": "https://pub.dev/api/archives/hooks-2.2.0.tar.gz",
+        "sha256": "eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/hooks-2.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/hooks-2.2.0"
     },
     {
         "type": "inline",
-        "contents": "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4",
+        "contents": "eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "hooks-2.1.0.sha256"
+        "dest-filename": "hooks-2.2.0.sha256"
     },
     {
         "type": "archive",
@@ -2366,16 +2366,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/image-4.8.0.tar.gz",
-        "sha256": "f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce",
+        "url": "https://pub.dev/api/archives/image-4.9.2.tar.gz",
+        "sha256": "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/image-4.8.0"
+        "dest": ".pub-cache/hosted/pub.dev/image-4.9.2"
     },
     {
         "type": "inline",
-        "contents": "f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce",
+        "contents": "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "image-4.8.0.sha256"
+        "dest-filename": "image-4.9.2.sha256"
     },
     {
         "type": "archive",
@@ -2688,16 +2688,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/jovial_svg-1.1.29.tar.gz",
-        "sha256": "99e9c3afcf7371ae38083ad52de23677d6d751f46150c3c6ae842e009e84d9f0",
+        "url": "https://pub.dev/api/archives/jovial_svg-1.1.30.tar.gz",
+        "sha256": "53d5ef08fafb28c56131bfd83894221597f522c324fb0f0e6fcbfdcae3b0867d",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/jovial_svg-1.1.29"
+        "dest": ".pub-cache/hosted/pub.dev/jovial_svg-1.1.30"
     },
     {
         "type": "inline",
-        "contents": "99e9c3afcf7371ae38083ad52de23677d6d751f46150c3c6ae842e009e84d9f0",
+        "contents": "53d5ef08fafb28c56131bfd83894221597f522c324fb0f0e6fcbfdcae3b0867d",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "jovial_svg-1.1.29.sha256"
+        "dest-filename": "jovial_svg-1.1.30.sha256"
     },
     {
         "type": "archive",
@@ -3024,16 +3024,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/matrix-10.0.1.tar.gz",
-        "sha256": "3d6c6b6dabbcca8e16a4ebfb19baddcd54a15654909d4b6a39fbc657f6727d01",
+        "url": "https://pub.dev/api/archives/matrix-10.2.1.tar.gz",
+        "sha256": "39519f0e9638d7229122a14155e3deba849fac9198d491a354bb24ebbc248871",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/matrix-10.0.1"
+        "dest": ".pub-cache/hosted/pub.dev/matrix-10.2.1"
     },
     {
         "type": "inline",
-        "contents": "3d6c6b6dabbcca8e16a4ebfb19baddcd54a15654909d4b6a39fbc657f6727d01",
+        "contents": "39519f0e9638d7229122a14155e3deba849fac9198d491a354bb24ebbc248871",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "matrix-10.0.1.sha256"
+        "dest-filename": "matrix-10.2.1.sha256"
     },
     {
         "type": "archive",
@@ -3248,16 +3248,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/native_toolchain_c-0.19.3.tar.gz",
-        "sha256": "a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60",
+        "url": "https://pub.dev/api/archives/native_toolchain_c-0.19.4.tar.gz",
+        "sha256": "9d233b6f2d9c52e1a2b5fbe70451d2c10ac674d3bb419d0ec8de14989d437c26",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/native_toolchain_c-0.19.3"
+        "dest": ".pub-cache/hosted/pub.dev/native_toolchain_c-0.19.4"
     },
     {
         "type": "inline",
-        "contents": "a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60",
+        "contents": "9d233b6f2d9c52e1a2b5fbe70451d2c10ac674d3bb419d0ec8de14989d437c26",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "native_toolchain_c-0.19.3.sha256"
+        "dest-filename": "native_toolchain_c-0.19.4.sha256"
     },
     {
         "type": "archive",
@@ -4130,16 +4130,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/record_use-1.1.0.tar.gz",
-        "sha256": "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee",
+        "url": "https://pub.dev/api/archives/record_use-1.1.1.tar.gz",
+        "sha256": "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/record_use-1.1.0"
+        "dest": ".pub-cache/hosted/pub.dev/record_use-1.1.1"
     },
     {
         "type": "inline",
-        "contents": "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee",
+        "contents": "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "record_use-1.1.0.sha256"
+        "dest-filename": "record_use-1.1.1.sha256"
     },
     {
         "type": "archive",
@@ -4633,16 +4633,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/source_maps-0.10.13.tar.gz",
-        "sha256": "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812",
+        "url": "https://pub.dev/api/archives/source_maps-0.10.14.tar.gz",
+        "sha256": "14c2945847669b44089bb1222f66873d7ff7103c58911917f2a63c5a62327898",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/source_maps-0.10.13"
+        "dest": ".pub-cache/hosted/pub.dev/source_maps-0.10.14"
     },
     {
         "type": "inline",
-        "contents": "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812",
+        "contents": "14c2945847669b44089bb1222f66873d7ff7103c58911917f2a63c5a62327898",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "source_maps-0.10.13.sha256"
+        "dest-filename": "source_maps-0.10.14.sha256"
     },
     {
         "type": "archive",
@@ -4717,16 +4717,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqflite_common_ffi-2.4.2.tar.gz",
-        "sha256": "5ccd38136edb9beb3213f6927775d52db70dfdadcdb28dad1f625ca9f2b9824f",
+        "url": "https://pub.dev/api/archives/sqflite_common_ffi-2.4.2+1.tar.gz",
+        "sha256": "d5564f1308cafbf064be498f2beb1e993e742985a7cca9e2e228d6cbccd84a05",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqflite_common_ffi-2.4.2"
+        "dest": ".pub-cache/hosted/pub.dev/sqflite_common_ffi-2.4.2+1"
     },
     {
         "type": "inline",
-        "contents": "5ccd38136edb9beb3213f6927775d52db70dfdadcdb28dad1f625ca9f2b9824f",
+        "contents": "d5564f1308cafbf064be498f2beb1e993e742985a7cca9e2e228d6cbccd84a05",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqflite_common_ffi-2.4.2.sha256"
+        "dest-filename": "sqflite_common_ffi-2.4.2+1.sha256"
     },
     {
         "type": "archive",
@@ -4759,16 +4759,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/sqlite3-3.5.1.tar.gz",
-        "sha256": "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478",
+        "url": "https://pub.dev/api/archives/sqlite3-3.5.2.tar.gz",
+        "sha256": "4c7fe79840389aaeaf05fd093f795b631b5a98e2bd28d54e555c100f4a9c7a1c",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/sqlite3-3.5.1"
+        "dest": ".pub-cache/hosted/pub.dev/sqlite3-3.5.2"
     },
     {
         "type": "inline",
-        "contents": "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478",
+        "contents": "4c7fe79840389aaeaf05fd093f795b631b5a98e2bd28d54e555c100f4a9c7a1c",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "sqlite3-3.5.1.sha256"
+        "dest-filename": "sqlite3-3.5.2.sha256"
     },
     {
         "type": "archive",
@@ -4955,16 +4955,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/synchronized-3.4.1+1.tar.gz",
-        "sha256": "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423",
+        "url": "https://pub.dev/api/archives/synchronized-3.4.1+2.tar.gz",
+        "sha256": "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/synchronized-3.4.1+1"
+        "dest": ".pub-cache/hosted/pub.dev/synchronized-3.4.1+2"
     },
     {
         "type": "inline",
-        "contents": "61894a1956de6b4fc1aefd0892e109514a1a706cbece3ac59decd90ff5a7a423",
+        "contents": "3a7b5d17422dd0f8d5c6c14feaa5a1c65638b9455f871a96f08437562c046931",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "synchronized-3.4.1+1.sha256"
+        "dest-filename": "synchronized-3.4.1+2.sha256"
     },
     {
         "type": "archive",
@@ -5473,16 +5473,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/vm_service-15.2.0.tar.gz",
-        "sha256": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
+        "url": "https://pub.dev/api/archives/vm_service-15.3.0.tar.gz",
+        "sha256": "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/vm_service-15.2.0"
+        "dest": ".pub-cache/hosted/pub.dev/vm_service-15.3.0"
     },
     {
         "type": "inline",
-        "contents": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
+        "contents": "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "vm_service-15.2.0.sha256"
+        "dest-filename": "vm_service-15.3.0.sha256"
     },
     {
         "type": "archive",
@@ -5739,16 +5739,16 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://pub.dev/api/archives/xml-6.6.1.tar.gz",
-        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "url": "https://pub.dev/api/archives/xml-7.0.1.tar.gz",
+        "sha256": "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4",
         "strip-components": 0,
-        "dest": ".pub-cache/hosted/pub.dev/xml-6.6.1"
+        "dest": ".pub-cache/hosted/pub.dev/xml-7.0.1"
     },
     {
         "type": "inline",
-        "contents": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "contents": "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
-        "dest-filename": "xml-6.6.1.sha256"
+        "dest-filename": "xml-7.0.1.sha256"
     },
     {
         "type": "archive",
@@ -5833,6 +5833,20 @@
         "contents": "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "built_value-8.12.6.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/code_assets-1.2.1.tar.gz",
+        "sha256": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/code_assets-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "code_assets-1.2.1.sha256"
     },
     {
         "type": "archive",
@@ -6145,6 +6159,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/source_maps-0.10.13.tar.gz",
+        "sha256": "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/source_maps-0.10.13"
+    },
+    {
+        "type": "inline",
+        "contents": "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "source_maps-0.10.13.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/sse-4.2.0.tar.gz",
         "sha256": "a9a804dbde8bfd369da3b4aa241d44d63a6486a97388c54ec166073d88c52302",
         "strip-components": 0,
@@ -6201,6 +6229,20 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/vm_service-15.2.0.tar.gz",
+        "sha256": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/vm_service-15.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "vm_service-15.2.0.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://pub.dev/api/archives/vm_service_interface-2.0.1.tar.gz",
         "sha256": "503c92c26cf9f77d688bf8fca27fa9ec40450adbf02ec1ec5f12828ded508ac0",
         "strip-components": 0,
@@ -6225,6 +6267,20 @@
         "contents": "5a79b9fbb6be2555090f55b03b23907e75d44c3fd7bdd88da09848aa5a1914c8",
         "dest": ".pub-cache/hosted-hashes/pub.dev",
         "dest-filename": "vm_snapshot_analysis-0.7.6.sha256"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://pub.dev/api/archives/xml-6.6.1.tar.gz",
+        "sha256": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "strip-components": 0,
+        "dest": ".pub-cache/hosted/pub.dev/xml-6.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025",
+        "dest": ".pub-cache/hosted-hashes/pub.dev",
+        "dest-filename": "xml-6.6.1.sha256"
     },
     {
         "type": "archive",
@@ -7166,7 +7222,7 @@
         "only-arches": [
             "x86_64"
         ],
-        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.1/libsqlite3.x64.linux.so",
+        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.2/libsqlite3.x64.linux.so",
         "sha256": "b17729184e5a2818055ecbddd5ed6642521bfe6e56aafa472330e483c0e2e0d2",
         "dest": "./.dart_tool/hooks_runner/shared/sqlite3/build/download-b1772918",
         "dest-filename": "libsqlite3.so"
@@ -7176,7 +7232,7 @@
         "only-arches": [
             "aarch64"
         ],
-        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.1/libsqlite3.arm64.linux.so",
+        "url": "https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-3.5.2/libsqlite3.arm64.linux.so",
         "sha256": "7f0db19fdb987298ab8def51431aba5cec28a81685e8b62cebbc7402df090a16",
         "dest": "./.dart_tool/hooks_runner/shared/sqlite3/build/download-7f0db19f",
         "dest-filename": "libsqlite3.so"


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4344` (upstream commit `a736cacff282`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32422278623](https://github.com/matthiasn/lotti/actions/runs/32422278623).
