### PR TITLE
chore: 1.0.11+4345

### DIFF
--- a/com.matthiasn.lotti.yml
+++ b/com.matthiasn.lotti.yml
@@ -132,7 +132,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/matthiasn/lotti
-        commit: a736cacff282e99745c38d15473342ca7fce1087
+        commit: c049dea2c176aabe25b0ed8529701b4d77852c5b
         disable-lfs: true
       - type: script
         dest-filename: lotti-wrapper.sh


### PR DESCRIPTION
Automated release submission for Lotti `1.0.11+4345` (upstream commit `c049dea2c176`).

Generated by .github/workflows/flathub-release-pr.yml from upstream run [#32426260942](https://github.com/matthiasn/lotti/actions/runs/32426260942).
